### PR TITLE
add clang-format rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,156 @@
+---
+Language:        Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/psi_cardinality/c/internal_utils.cpp
+++ b/psi_cardinality/c/internal_utils.cpp
@@ -1,6 +1,6 @@
-#include <string.h>
-
 #include "internal_utils.h"
+
+#include <string.h>
 
 namespace psi_cardinality {
 namespace c_bindings_internal {
@@ -12,5 +12,5 @@ int generate_error(private_join_and_compute::Status status, char **error_out) {
   }
   return status.error_code();
 }
-} // namespace c_bindings_internal
-} // namespace psi_cardinality
+}  // namespace c_bindings_internal
+}  // namespace psi_cardinality

--- a/psi_cardinality/c/internal_utils.h
+++ b/psi_cardinality/c/internal_utils.h
@@ -25,5 +25,5 @@ namespace c_bindings_internal {
 int generate_error(private_join_and_compute::Status status, char **error_out);
 
 }
-} // namespace psi_cardinality
-#endif // PSI_CARDINALITY_INTERNAL_UTILS_H_
+}  // namespace psi_cardinality
+#endif  // PSI_CARDINALITY_INTERNAL_UTILS_H_

--- a/psi_cardinality/c/psi_cardinality_benchmark_c.cpp
+++ b/psi_cardinality/c/psi_cardinality_benchmark_c.cpp
@@ -191,5 +191,5 @@ void BM_ClientProcessResponse(benchmark::State &state) {
 // Range is for the number of inputs.
 BENCHMARK(BM_ClientProcessResponse)->RangeMultiplier(10)->Range(1, 10000);
 
-} // namespace
-} // namespace psi_cardinality
+}  // namespace
+}  // namespace psi_cardinality

--- a/psi_cardinality/c/psi_cardinality_client_c.h
+++ b/psi_cardinality/c/psi_cardinality_client_c.h
@@ -49,4 +49,4 @@ int psi_cardinality_client_process_response(psi_cardinality_client_ctx,
 }
 #endif
 
-#endif // PSI_CARDINALITY_PSI_CARDINALITY_CLIENT_C_H_
+#endif  // PSI_CARDINALITY_PSI_CARDINALITY_CLIENT_C_H_

--- a/psi_cardinality/c/psi_cardinality_client_test_c.cpp
+++ b/psi_cardinality/c/psi_cardinality_client_test_c.cpp
@@ -18,18 +18,18 @@
 #include "absl/strings/str_cat.h"
 #include "bloom_filter.h"
 #include "crypto/ec_commutative_cipher.h"
+#include "gtest/gtest.h"
 #include "psi_cardinality_client_c.h"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "util/status_matchers.h"
-#include "gtest/gtest.h"
 
 namespace psi_cardinality {
 namespace {
 
 class PSICardinalityClientTest : public ::testing::Test {
-protected:
+ protected:
   void SetUp() {
     char *err;
     int ret = psi_cardinality_client_create(&client_, &err);
@@ -138,5 +138,5 @@ TEST_F(PSICardinalityClientTest, TestCorrectness) {
   psi_cardinality_client_delete_buffer(client_, &client_request);
 }
 
-} // namespace
-} // namespace psi_cardinality
+}  // namespace
+}  // namespace psi_cardinality

--- a/psi_cardinality/c/psi_cardinality_server_c.cpp
+++ b/psi_cardinality/c/psi_cardinality_server_c.cpp
@@ -58,7 +58,6 @@ int psi_cardinality_server_create_setup_message(
 
   auto result = server->CreateSetupMessage(fpr, num_client_inputs, in);
   if (!result.ok()) {
-
     return psi_cardinality::c_bindings_internal::generate_error(result.status(),
                                                                 error_out);
   }

--- a/psi_cardinality/c/psi_cardinality_server_c.h
+++ b/psi_cardinality/c/psi_cardinality_server_c.h
@@ -57,4 +57,4 @@ int psi_cardinality_server_get_private_key_bytes(psi_cardinality_server_ctx ctx,
 }
 #endif
 
-#endif // PSI_CARDINALITY_PSI_CARDINALITY_SERVER_C_H_
+#endif  // PSI_CARDINALITY_PSI_CARDINALITY_SERVER_C_H_

--- a/psi_cardinality/c/psi_cardinality_server_test_c.cpp
+++ b/psi_cardinality/c/psi_cardinality_server_test_c.cpp
@@ -16,16 +16,16 @@
 
 #include "absl/strings/str_cat.h"
 #include "crypto/ec_commutative_cipher.h"
+#include "gtest/gtest.h"
 #include "psi_cardinality_client_c.h"
 #include "psi_cardinality_server_c.h"
 #include "util/status_matchers.h"
-#include "gtest/gtest.h"
 
 namespace psi_cardinality {
 namespace {
 
 class PSICardinalityServerTest : public ::testing::Test {
-protected:
+ protected:
   void SetUp() {
     char *err;
     int ret = psi_cardinality_server_create_with_new_key(&server_, &err);
@@ -114,5 +114,5 @@ TEST_F(PSICardinalityServerTest, TestCorrectness) {
   psi_cardinality_client_delete_buffer(client_, &client_request);
 }
 
-} // namespace
-} // namespace psi_cardinality
+}  // namespace
+}  // namespace psi_cardinality

--- a/psi_cardinality/cpp/bloom_filter.cpp
+++ b/psi_cardinality/cpp/bloom_filter.cpp
@@ -15,7 +15,9 @@
 //
 
 #include "bloom_filter.h"
+
 #include <cmath>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"

--- a/psi_cardinality/cpp/bloom_filter.h
+++ b/psi_cardinality/cpp/bloom_filter.h
@@ -18,6 +18,7 @@
 #define PSI_CARDINALITY_BLOOM_FILTER_H_
 
 #include <vector>
+
 #include "absl/types/span.h"
 #include "crypto/context.h"
 #include "util/statusor.h"
@@ -43,8 +44,8 @@ class BloomFilter {
   BloomFilter() = delete;
 
   // Creates a new Bloom filter. As long as less than `max_elements` are
-  // inserted, the probability of false positives when performing checks against
-  // the returned Bloom filter is less than `fpr`.
+  // inserted, the probability of false positives when performing checks
+  // against the returned Bloom filter is less than `fpr`.
   //
   // Returns INVALID_ARGUMENT if fpr is not in (0,1) or max_elements is not
   // positive.
@@ -85,10 +86,10 @@ class BloomFilter {
   BloomFilter(int num_hash_functions, std::string bits,
               std::unique_ptr<::private_join_and_compute::Context> context);
 
-  // Hashes the input with all `num_hash_functions_` hash functions and returns
-  // the result as a vector. The i-th hash  hash function is computed as
-  // SHA256(1 || x) + i * SHA256(2 || x) (modulo num_bits), where x is the input
-  // and num_bits is the number of bits in the Bloom filter.
+  // Hashes the input with all `num_hash_functions_` hash functions and
+  // returns the result as a vector. The i-th hash  hash function is computed
+  // as SHA256(1 || x) + i * SHA256(2 || x) (modulo num_bits), where x is the
+  // input and num_bits is the number of bits in the Bloom filter.
   std::vector<int64_t> Hash(const std::string& input) const;
 
   // Number of hash functions.

--- a/psi_cardinality/cpp/bloom_filter_test.cpp
+++ b/psi_cardinality/cpp/bloom_filter_test.cpp
@@ -15,6 +15,7 @@
 //
 
 #include "bloom_filter.h"
+
 #include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 #include "util/status_matchers.h"
@@ -82,7 +83,8 @@ TEST_F(BloomFilterTest, TestToJSON) {
   std::string encoded_filter = filter_->ToJSON();
   std::string expected =
       "{\"num_hash_functions\":7,\"bits\":\"VN3/"
-      "BXfUjEDvJLcxCTepUCTXGQwlTax0xHiMohCNb45uShFsznK099RH0CFVIMn91Bdc7jLkXHXr"
+      "BXfUjEDvJLcxCTepUCTXGQwlTax0xHiMohCNb45uShFsznK099RH0CFVIMn91Bdc7jLkXH"
+      "Xr"
       "Xp1NimmZSDrYSj5sd/"
       "500nroNOdXbtd53u8cejPMGxbx7kR1E1zyO19mSkYLXq4xf7au5dFN0qhxqfLnjaCE\"}";
   EXPECT_EQ(encoded_filter, expected);

--- a/psi_cardinality/cpp/psi_cardinality_client.cpp
+++ b/psi_cardinality/cpp/psi_cardinality_client.cpp
@@ -15,12 +15,14 @@
 //
 
 #include "psi_cardinality_client.h"
+
 #include <vector>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
-#include "openssl/obj_mac.h"
 #include "bloom_filter.h"
+#include "openssl/obj_mac.h"
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"
 #include "rapidjson/stringbuffer.h"
@@ -53,8 +55,8 @@ StatusOr<std::string> PSICardinalityClient::CreateRequest(
     ASSIGN_OR_RETURN(encrypted_inputs[i], ec_cipher_->Encrypt(inputs[i]));
   }
 
-  // Sort inputs (same effect as shuffling as they are encrypted) and store them
-  // in a JSON array.
+  // Sort inputs (same effect as shuffling as they are encrypted) and store
+  // them in a JSON array.
   rapidjson::Document request;
   request.SetArray();
   std::sort(encrypted_inputs.begin(), encrypted_inputs.end());

--- a/psi_cardinality/cpp/psi_cardinality_client.h
+++ b/psi_cardinality/cpp/psi_cardinality_client.h
@@ -86,20 +86,20 @@ class PSICardinalityClient {
   // Returns INTERNAL if any OpenSSL crypto operations fail.
   static StatusOr<std::unique_ptr<PSICardinalityClient>> Create();
 
-  // Creates a request message to be sent to the server. For each input element
-  // x, computes H(x)^c, where c is the secret key of ec_cipher_. The result is
-  // sorted to hide the initial ordering of `inputs` and encoded as a JSON
-  // array.
+  // Creates a request message to be sent to the server. For each input
+  // element x, computes H(x)^c, where c is the secret key of ec_cipher_. The
+  // result is sorted to hide the initial ordering of `inputs` and encoded as
+  // a JSON array.
   //
   // Returns INTERNAL if encryption fails.
   StatusOr<std::string> CreateRequest(
       absl::Span<const std::string> inputs) const;
 
-  // Processes the server's response and returns the PSI cardinality. The first
-  // argument, `server_setup`, is a bloom filter that encodes encrypted server
-  // elements and is sent by the server in a setup phase. The second argument,
-  // `server_response`, is the response received from the server after sending
-  // the result of `CreateRequest`.
+  // Processes the server's response and returns the PSI cardinality. The
+  // first argument, `server_setup`, is a bloom filter that encodes encrypted
+  // server elements and is sent by the server in a setup phase. The second
+  // argument, `server_response`, is the response received from the server
+  // after sending the result of `CreateRequest`.
   //
   // Returns INVALID_ARGUMENT if any input messages are malformed, or INTERNAL
   // if decryption fails.

--- a/psi_cardinality/cpp/psi_cardinality_client_test.cpp
+++ b/psi_cardinality/cpp/psi_cardinality_client_test.cpp
@@ -15,11 +15,12 @@
 //
 
 #include "psi_cardinality_client.h"
+
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
+#include "bloom_filter.h"
 #include "crypto/ec_commutative_cipher.h"
 #include "gtest/gtest.h"
-#include "bloom_filter.h"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"

--- a/psi_cardinality/cpp/psi_cardinality_server.cpp
+++ b/psi_cardinality/cpp/psi_cardinality_server.cpp
@@ -15,12 +15,14 @@
 //
 
 #include "psi_cardinality_server.h"
+
 #include <vector>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
-#include "openssl/obj_mac.h"
 #include "bloom_filter.h"
+#include "openssl/obj_mac.h"
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"
 #include "rapidjson/stringbuffer.h"

--- a/psi_cardinality/cpp/psi_cardinality_server.h
+++ b/psi_cardinality/cpp/psi_cardinality_server.h
@@ -43,10 +43,10 @@ class PSICardinalityServer {
   static StatusOr<std::unique_ptr<PSICardinalityServer>> CreateFromKey(
       const std::string& key_bytes);
 
-  // Creates a setup message from the server's dataset to be sent to the client.
-  // The setup message is a JSON-encoded Bloom filter containing H(x)^s for each
-  // element x in `inputs`, where s is the server's secret key. The message has
-  // the following form:
+  // Creates a setup message from the server's dataset to be sent to the
+  // client. The setup message is a JSON-encoded Bloom filter containing
+  // H(x)^s for each element x in `inputs`, where s is the server's secret
+  // key. The message has the following form:
   //
   //   {
   //     "num_hash_functions": <int>,
@@ -65,14 +65,14 @@ class PSICardinalityServer {
   // Processes a client query and returns the corresponding server response to
   // be sent to the client. For each encrytped element H(x)^c in the decoded
   // `client_request`, computes (H(x)^c)^s = H(X)^(cs) and returns these as a
-  // sorted JSON array. Sorting the output prevents the client from matching the
-  // individual response elements to the ones in the request, ensuring that they
-  // can only learn the intersection size but not individual elements in the
-  // intersection.
+  // sorted JSON array. Sorting the output prevents the client from matching
+  // the individual response elements to the ones in the request, ensuring
+  // that they can only learn the intersection size but not individual
+  // elements in the intersection.
   StatusOr<std::string> ProcessRequest(const std::string& client_request) const;
 
-  // Returns this instance's private key. This key should only be used to create
-  // other server instances. DO NOT SEND THIS KEY TO ANY OTHER PARTY!
+  // Returns this instance's private key. This key should only be used to
+  // create other server instances. DO NOT SEND THIS KEY TO ANY OTHER PARTY!
   std::string GetPrivateKeyBytes() const;
 
  private:

--- a/psi_cardinality/cpp/psi_cardinality_server_test.cpp
+++ b/psi_cardinality/cpp/psi_cardinality_server_test.cpp
@@ -15,6 +15,7 @@
 //
 
 #include "psi_cardinality_server.h"
+
 #include "absl/strings/str_cat.h"
 #include "crypto/ec_commutative_cipher.h"
 #include "gtest/gtest.h"
@@ -34,8 +35,8 @@ class PSICardinalityServerTest : public ::testing::Test {
 };
 
 TEST_F(PSICardinalityServerTest, TestCorrectness) {
-  // We use an actual client instance here, since we already test the client on
-  // its own in psi_cardinality_client_test.cpp.
+  // We use an actual client instance here, since we already test the client
+  // on its own in psi_cardinality_client_test.cpp.
   PSI_ASSERT_OK_AND_ASSIGN(auto client, PSICardinalityClient::Create());
   int num_client_elements = 1000, num_server_elements = 10000;
   double fpr = 0.01;

--- a/psi_cardinality/go/client/client.go
+++ b/psi_cardinality/go/client/client.go
@@ -75,6 +75,7 @@ func (c *PSICardinalityClient) ProcessResponse(serverSetup, serverResponse strin
 	return int64(result), nil
 }
 
+//Destroy the C context
 func (c *PSICardinalityClient) Destroy() {
 	if c.context == nil {
 		return

--- a/psi_cardinality/go/server/server.go
+++ b/psi_cardinality/go/server/server.go
@@ -127,6 +127,7 @@ func (s *PSICardinalityServer) GetPrivateKeyBytes() (string, error) {
 	return result, nil
 }
 
+//Destroy the C context
 func (s *PSICardinalityServer) Destroy() {
 	if s.context == nil {
 		return
@@ -135,8 +136,8 @@ func (s *PSICardinalityServer) Destroy() {
 	s.context = nil
 }
 
-func (c *PSICardinalityServer) loadCString(buff **C.char) string {
+func (s *PSICardinalityServer) loadCString(buff **C.char) string {
 	str := C.GoString(*buff)
-	C.psi_cardinality_server_delete_buffer(c.context, buff)
+	C.psi_cardinality_server_delete_buffer(s.context, buff)
 	return str
 }

--- a/psi_cardinality/javascript/bindings/client.cpp
+++ b/psi_cardinality/javascript/bindings/client.cpp
@@ -1,4 +1,5 @@
 #include <emscripten/bind.h>
+
 #include "psi_cardinality/cpp/psi_cardinality_client.h"
 #include "psi_cardinality/javascript/bindings/utils.h"
 
@@ -20,7 +21,8 @@ EMSCRIPTEN_BINDINGS(PSI_Client) {
                 optional_override([](const PSICardinalityClient &self,
                                      const emscripten::val &string_array) {
                   std::vector<std::string> string_vector;
-                  const std::uint32_t l = string_array["length"].as<std::uint32_t>();
+                  const std::uint32_t l =
+                      string_array["length"].as<std::uint32_t>();
                   string_vector.reserve(l);
 
                   for (std::uint32_t i = 0; i < l; ++i) {

--- a/psi_cardinality/javascript/bindings/server.cpp
+++ b/psi_cardinality/javascript/bindings/server.cpp
@@ -1,4 +1,5 @@
 #include <emscripten/bind.h>
+
 #include "psi_cardinality/cpp/psi_cardinality_server.h"
 #include "psi_cardinality/javascript/bindings/utils.h"
 
@@ -16,33 +17,35 @@ EMSCRIPTEN_BINDINGS(PSI_Server) {
                             ToShared(PSICardinalityServer::CreateWithNewKey()));
                       }))
       .class_function(
-          "CreateFromKey", optional_override([](const emscripten::val &byte_array) {
+          "CreateFromKey",
+          optional_override([](const emscripten::val &byte_array) {
             const std::uint32_t l = byte_array["length"].as<std::uint32_t>();
             std::string byte_string(l, '\0');
 
             for (std::uint32_t i = 0; i < l; i++) {
-                byte_string[i] = byte_array[i].as<std::uint8_t>();
+              byte_string[i] = byte_array[i].as<std::uint8_t>();
             }
 
             return ToJSObject(
                 ToShared(PSICardinalityServer::CreateFromKey(byte_string)));
           }))
-      .function(
-          "CreateSetupMessage",
-          optional_override(
-              [](const PSICardinalityServer &self, const double fpr,
-                 const int32_t num_client_inputs, const emscripten::val &string_array) {
-                std::vector<std::string> string_vector;
-                const std::uint32_t l = string_array["length"].as<std::uint32_t>();
-                string_vector.reserve(l);
+      .function("CreateSetupMessage",
+                optional_override([](const PSICardinalityServer &self,
+                                     const double fpr,
+                                     const int32_t num_client_inputs,
+                                     const emscripten::val &string_array) {
+                  std::vector<std::string> string_vector;
+                  const std::uint32_t l =
+                      string_array["length"].as<std::uint32_t>();
+                  string_vector.reserve(l);
 
-                for (std::uint32_t i = 0; i < l; ++i) {
-                  string_vector.push_back(string_array[i].as<std::string>());
-                }
+                  for (std::uint32_t i = 0; i < l; ++i) {
+                    string_vector.push_back(string_array[i].as<std::string>());
+                  }
 
-                return ToJSObject(
-                    self.CreateSetupMessage(fpr, num_client_inputs, string_vector));
-              }))
+                  return ToJSObject(self.CreateSetupMessage(
+                      fpr, num_client_inputs, string_vector));
+                }))
       .function("ProcessRequest",
                 optional_override([](const PSICardinalityServer &self,
                                      const std::string &client_request) {
@@ -51,8 +54,10 @@ EMSCRIPTEN_BINDINGS(PSI_Server) {
       .function("GetPrivateKeyBytes",
                 optional_override([](const PSICardinalityServer &self) {
                   const std::string byte_string = self.GetPrivateKeyBytes();
-                  const std::vector<std::uint8_t> byte_vector(byte_string.begin(), byte_string.end());
-                  emscripten::val byte_array  = emscripten::val::array(byte_vector.begin(), byte_vector.end());
+                  const std::vector<std::uint8_t> byte_vector(
+                      byte_string.begin(), byte_string.end());
+                  emscripten::val byte_array = emscripten::val::array(
+                      byte_vector.begin(), byte_vector.end());
                   return byte_array;
                 }));
 }

--- a/psi_cardinality/javascript/bindings/utils.h
+++ b/psi_cardinality/javascript/bindings/utils.h
@@ -2,7 +2,9 @@
 #define PSI_CARDINALITY_JAVASCRIPT_BINDINGS_UTILS_H_
 
 #include <emscripten/val.h>
+
 #include <vector>
+
 #include "util/statusor.h"
 
 namespace psi_cardinality {


### PR DESCRIPTION
- .clang-format rules
- run clang-format-9 with style=google

After enabling the Github Workflows we should add clang-format and gofmt/golint rules to the test set.