### PR TITLE
Fix Go bindings

### DIFF
--- a/psi_cardinality/c/internal_utils.h
+++ b/psi_cardinality/c/internal_utils.h
@@ -23,7 +23,6 @@ namespace psi_cardinality {
 
 namespace c_bindings_internal {
 int generate_error(private_join_and_compute::Status status, char **error_out);
-
 }
 }  // namespace psi_cardinality
 #endif  // PSI_CARDINALITY_INTERNAL_UTILS_H_

--- a/psi_cardinality/c/psi_cardinality_client_test_c.cpp
+++ b/psi_cardinality/c/psi_cardinality_client_test_c.cpp
@@ -16,9 +16,9 @@
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
-#include "psi_cardinality/cpp/bloom_filter.h"
 #include "crypto/ec_commutative_cipher.h"
 #include "gtest/gtest.h"
+#include "psi_cardinality/cpp/bloom_filter.h"
 #include "psi_cardinality_client_c.h"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"

--- a/psi_cardinality/c/psi_cardinality_server_c.cpp
+++ b/psi_cardinality/c/psi_cardinality_server_c.cpp
@@ -41,8 +41,8 @@ void psi_cardinality_server_delete(psi_cardinality_server_ctx *ctx) {
 
 int psi_cardinality_server_create_setup_message(
     psi_cardinality_server_ctx ctx, double fpr, int64_t num_client_inputs,
-    server_buffer_t *input, size_t input_len, char **output,
-    size_t *output_len, char **error_out) {
+    server_buffer_t *input, size_t input_len, char **output, size_t *output_len,
+    char **error_out) {
   auto server = static_cast<Server *>(ctx);
   if (server == nullptr) {
     return psi_cardinality::c_bindings_internal::generate_error(
@@ -111,9 +111,11 @@ int psi_cardinality_server_get_private_key_bytes(psi_cardinality_server_ctx ctx,
         error_out);
   }
   auto value = server->GetPrivateKeyBytes();
-  size_t len = value.size() + 1;
+  size_t len = value.size();
+
+  // Private keys are raw bytes -> Use memcpy instead of strncpy.
   *output = new char[len];
-  strncpy(*output, value.c_str(), len);
+  memcpy(*output, value.data(), len);
   *output_len = len;
 
   return 0;

--- a/psi_cardinality/cpp/psi_cardinality_server_test.cpp
+++ b/psi_cardinality/cpp/psi_cardinality_server_test.cpp
@@ -83,7 +83,8 @@ TEST_F(PSICardinalityServerTest, TestCreatingFromKey) {
   EXPECT_EQ(key_bytes.length(), 32);
 
   // Create a new server instance from the original key
-  PSI_ASSERT_OK_AND_ASSIGN(auto server, PSICardinalityServer::CreateFromKey(key_bytes));
+  PSI_ASSERT_OK_AND_ASSIGN(auto server,
+                           PSICardinalityServer::CreateFromKey(key_bytes));
 
   int num_client_elements = 100, num_server_elements = 1000;
   double fpr = 0.01;
@@ -110,13 +111,16 @@ TEST_F(PSICardinalityServerTest, TestCreatingFromKey) {
   // Both setup messages should be the same
   EXPECT_EQ(server_setup, server_setup1);
 
-  // Create a 31-byte key that should be equivalent to a 32-byte null-inserted key
+  // Create a 31-byte key that should be equivalent to a 32-byte null-inserted
+  // key
   const std::string key_bytes2("bcdefghijklmnopqrstuvwxyz123456", 31);
-  PSI_ASSERT_OK_AND_ASSIGN(auto server2, PSICardinalityServer::CreateFromKey(key_bytes2));
+  PSI_ASSERT_OK_AND_ASSIGN(auto server2,
+                           PSICardinalityServer::CreateFromKey(key_bytes2));
   const std::string key_bytes3("\0bcdefghijklmnopqrstuvwxyz123456", 32);
-  PSI_ASSERT_OK_AND_ASSIGN(auto server3, PSICardinalityServer::CreateFromKey(key_bytes3));
+  PSI_ASSERT_OK_AND_ASSIGN(auto server3,
+                           PSICardinalityServer::CreateFromKey(key_bytes3));
 
-    // Run Server setup.
+  // Run Server setup.
   PSI_ASSERT_OK_AND_ASSIGN(
       auto server_setup2,
       server2->CreateSetupMessage(fpr, num_client_elements, server_elements));

--- a/psi_cardinality/go/server/server.go
+++ b/psi_cardinality/go/server/server.go
@@ -205,7 +205,7 @@ func (s *PSICardinalityServer) GetPrivateKeyBytes() ([]byte, error) {
 		return nil, fmt.Errorf("get private keys failed: %v(%v)", s.loadCString(&err), rcode)
 	}
 
-    // Convert C array to a Go slice. Private Keys are guaranteed to be 32 bytes long.
+	// Convert C array to a Go slice. Private Keys are guaranteed to be 32 bytes long.
 	result := (*[32]byte)(unsafe.Pointer(out))[:outlen:outlen]
 
 	return result, nil

--- a/psi_cardinality/go/server/server.go
+++ b/psi_cardinality/go/server/server.go
@@ -96,7 +96,7 @@ func CreateFromKey(key []byte) (*PSICardinalityServer, error) {
 
 	var err *C.char
 	rcode := C.psi_cardinality_server_create_from_key(C.struct_server_buffer_t{
-		buff:     (*C.char)(unsafe.Pointer(&key[0])),
+		buff:     (*C.char)(C.CBytes(key)),
 		buff_len: C.size_t(len(key)),
 	},
 		&psiServer.context, &err)
@@ -206,7 +206,7 @@ func (s *PSICardinalityServer) GetPrivateKeyBytes() ([]byte, error) {
 	}
 
 	// Convert C array to a Go slice. Private Keys are guaranteed to be 32 bytes long.
-	result := (*[32]byte)(unsafe.Pointer(out))[:outlen:outlen]
+	result := C.GoBytes(unsafe.Pointer(out), 32)
 
 	return result, nil
 }

--- a/psi_cardinality/go/server/server_test.go
+++ b/psi_cardinality/go/server/server_test.go
@@ -1,9 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"github.com/openmined/psi-cardinality/client"
 	"testing"
-	"bytes"
 )
 
 func TestServerSanity(t *testing.T) {

--- a/psi_cardinality/go/server/server_test.go
+++ b/psi_cardinality/go/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"github.com/openmined/psi-cardinality/client"
 	"testing"
+	"bytes"
 )
 
 func TestServerSanity(t *testing.T) {
@@ -25,7 +26,7 @@ func TestServerSanity(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to create a new PSI server key %v", err)
 	}
-	if key != newKey {
+	if !bytes.Equal(key, newKey) {
 		t.Errorf("new server invalid")
 	}
 	server.Destroy()


### PR DESCRIPTION
Private keys are raw bytes, so they need to be converted to []byte instead of string.