### PR TITLE
fix: upgrade to latest emsdk

### DIFF
--- a/psi_cardinality/javascript/custom_types/psi-cardinality/index.d.ts
+++ b/psi_cardinality/javascript/custom_types/psi-cardinality/index.d.ts
@@ -51,7 +51,6 @@ declare module 'psi_cardinality*' {
   }
 
   export type Library = {
-    onRuntimeInitialized: () => void
     readonly delete: () => void
     readonly CreateSetupMessage: (
       fpr: number,
@@ -74,5 +73,5 @@ declare module 'psi_cardinality*' {
     }
   }
 
-  export default function bin(): Library
+  export default function bin(): Promise<Library>
 }

--- a/psi_cardinality/javascript/src/loader.ts
+++ b/psi_cardinality/javascript/src/loader.ts
@@ -3,24 +3,14 @@ import * as psiCardinality from 'psi_cardinality'
 type NestedLibrary = { readonly library: psiCardinality.Library }
 export type Loader = () => Promise<NestedLibrary>
 
-/*
- * Emscripten output contains this callback (onRuntimeInitialized)
- * which fires when the library is fully initialized.
- *
- * We're simply converting this into a promise.
- */
-const waitUntilReady = (src: psiCardinality.Library): Promise<void> =>
-  new Promise(resolve => (src.onRuntimeInitialized = resolve))
-
 /**
  * Export a default function which instantiates the library
  * @param {Object} bin Emscripten library to initialize
  */
 export const createLoader = (
-  bin: () => psiCardinality.Library
+  bin: () => Promise<psiCardinality.Library>
 ): Loader => async (): Promise<NestedLibrary> => {
-  const library = bin()
-  await waitUntilReady(library)
+  const library = await bin()
   return {
     library
   }


### PR DESCRIPTION
The latest emscripten release has a breaking change on module initialization.

Instead of creating an instance that offers callback `onRuntimeInitialized`, it now returns a promise with the module fully initialized.