### PR TITLE
Feat use emmalloc for emscripten

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,5 @@
 [Will Clark](https://github.com/willclarktech)
 
 [Phillipp Schoppmann](https://github.com/schoppmp)
+
+[Rutuja Surve](https://github.com/rutujasurve94)

--- a/psi_cardinality/javascript/BUILD
+++ b/psi_cardinality/javascript/BUILD
@@ -4,6 +4,7 @@ DEFAULT_EMSCRIPTEN_LINKOPTS = [
     "-flto",
     "--bind",
     "--closure 1",
+    "-s MALLOC=emmalloc",
     "-s ALLOW_MEMORY_GROWTH=1",
     "-s USE_PTHREADS=0",
     "-s ASSERTIONS=0",


### PR DESCRIPTION
This small PR replaces `dlmalloc` with emscriptens smaller `emmalloc` resulting in a slight reduction in code size. Performance difference appears negligible. 