### PR TITLE
feat: client can now be created from a key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Run tests
         run: .github/workflows/scripts/run_tests_js.sh
 
-
   Python:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -46,18 +45,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r private_set_intersection/python/requirements_dev.txt
-      - name: Python linters
-        run: .github/workflows/scripts/lint_python.sh
       - name: Run tests
         run: .github/workflows/scripts/run_tests_python.sh
-
+      - name: Python linters
+        run: .github/workflows/scripts/lint_python.sh
 
   Go:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-18.04]
- 
+
     steps:
       - name: Install toolchains
         uses: actions/setup-go@v2
@@ -67,7 +65,7 @@ jobs:
       - name: Install Go dependencies
         run: go get -u golang.org/x/lint/golint
       - uses: actions/checkout@v2
-      - name: Go linters
-        run: .github/workflows/scripts/lint_go.sh
       - name: Run tests
         run: .github/workflows/scripts/run_tests_go.sh
+      - name: Go linters
+        run: .github/workflows/scripts/lint_go.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,6 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-18.04]
-
     steps:
       - name: Install toolchains
         uses: actions/setup-go@v2

--- a/private_set_intersection/c/psi_benchmark.cpp
+++ b/private_set_intersection/c/psi_benchmark.cpp
@@ -62,7 +62,7 @@ BENCHMARK_CAPTURE(BM_ServerSetup, 0.000001 intersection, 0.000001, true)
 void BM_ClientCreateRequest(benchmark::State &state, bool reveal_intersection) {
   psi_client_ctx client_;
   char *err;
-  psi_client_create(reveal_intersection, &client_, &err);
+  psi_client_create_with_new_key(reveal_intersection, &client_, &err);
 
   int num_inputs = state.range(0);
   std::vector<std::string> inputs_orig(num_inputs);
@@ -107,7 +107,7 @@ void BM_ServerProcessRequest(benchmark::State &state,
   psi_server_ctx server_;
   char *err;
 
-  psi_client_create(reveal_intersection, &client_, &err);
+  psi_client_create_with_new_key(reveal_intersection, &client_, &err);
   psi_server_create_with_new_key(reveal_intersection, &server_, &err);
 
   int num_inputs = state.range(0);
@@ -160,7 +160,7 @@ void BM_ClientProcessResponse(benchmark::State &state,
   psi_client_ctx client_;
   psi_server_ctx server_;
   char *err;
-  psi_client_create(reveal_intersection, &client_, &err);
+  psi_client_create_with_new_key(reveal_intersection, &client_, &err);
   psi_server_create_with_new_key(reveal_intersection, &server_, &err);
 
   int num_inputs = state.range(0);

--- a/private_set_intersection/c/psi_client.h
+++ b/private_set_intersection/c/psi_client.h
@@ -32,8 +32,11 @@ struct psi_client_buffer_t {
   size_t buff_len;
 };
 
-int psi_client_create(bool reveal_intersection, psi_client_ctx *ctx,
-                      char **error_out);
+int psi_client_create_with_new_key(bool reveal_intersection,
+                                   psi_client_ctx *ctx, char **error_out);
+int psi_client_create_from_key(struct psi_client_buffer_t key_bytes,
+                               bool reveal_intersection, psi_client_ctx *ctx,
+                               char **error_out);
 void psi_client_delete(psi_client_ctx *ctx);
 int psi_client_create_request(psi_client_ctx ctx,
                               struct psi_client_buffer_t *inputs,
@@ -46,7 +49,8 @@ int psi_client_get_intersection_size(psi_client_ctx ctx,
 int psi_client_get_intersection(psi_client_ctx ctx, const char *server_setup,
                                 const char *server_response, int64_t **out,
                                 size_t *out_len, char **error_out);
-
+int psi_client_get_private_key_bytes(psi_client_ctx ctx, char **output,
+                                     size_t *output_len, char **error_out);
 #ifdef __cplusplus
 }
 #endif

--- a/private_set_intersection/c/psi_client_test.cpp
+++ b/private_set_intersection/c/psi_client_test.cpp
@@ -40,7 +40,7 @@ void test_corectness(bool reveal_intersection) {
   psi_client_ctx client_;
 
   char *err;
-  int ret = psi_client_create(reveal_intersection, &client_, &err);
+  int ret = psi_client_create_with_new_key(reveal_intersection, &client_, &err);
   ASSERT_TRUE(client_ != nullptr);
   ASSERT_TRUE(ret == 0);
   constexpr int num_client_elements = 1000, num_server_elements = 10000;

--- a/private_set_intersection/c/psi_server_test.cpp
+++ b/private_set_intersection/c/psi_server_test.cpp
@@ -39,7 +39,7 @@ void test_correctness(bool reveal_intersection) {
   ASSERT_TRUE(server_ != nullptr);
   ASSERT_TRUE(ret == 0);
   psi_client_ctx client_;
-  psi_client_create(reveal_intersection, &client_, &err);
+  psi_client_create_with_new_key(reveal_intersection, &client_, &err);
 
   ASSERT_TRUE(client_ != nullptr);
 

--- a/private_set_intersection/cpp/psi_benchmark.cpp
+++ b/private_set_intersection/cpp/psi_benchmark.cpp
@@ -45,7 +45,7 @@ BENCHMARK_CAPTURE(BM_ServerSetup, 0.000001 intersection, 0.000001, true)
     ->Range(1, 1000000);
 
 void BM_ClientCreateRequest(benchmark::State& state, bool reveal_intersection) {
-  auto client = PsiClient::Create(reveal_intersection).ValueOrDie();
+  auto client = PsiClient::CreateWithNewKey(reveal_intersection).ValueOrDie();
   int num_inputs = state.range(0);
   std::vector<std::string> inputs(num_inputs);
   for (int i = 0; i < num_inputs; i++) {
@@ -74,7 +74,7 @@ BENCHMARK_CAPTURE(BM_ClientCreateRequest, intersection, true)
 
 void BM_ServerProcessRequest(benchmark::State& state,
                              bool reveal_intersection) {
-  auto client = PsiClient::Create(reveal_intersection).ValueOrDie();
+  auto client = PsiClient::CreateWithNewKey(reveal_intersection).ValueOrDie();
   auto server = PsiServer::CreateWithNewKey(reveal_intersection).ValueOrDie();
   int num_inputs = state.range(0);
   std::vector<std::string> inputs(num_inputs);
@@ -105,7 +105,7 @@ BENCHMARK_CAPTURE(BM_ServerProcessRequest, intersection, true)
 
 void BM_ClientProcessResponse(benchmark::State& state,
                               bool reveal_intersection) {
-  auto client = PsiClient::Create(reveal_intersection).ValueOrDie();
+  auto client = PsiClient::CreateWithNewKey(reveal_intersection).ValueOrDie();
   auto server = PsiServer::CreateWithNewKey(reveal_intersection).ValueOrDie();
   int num_inputs = state.range(0);
   double fpr = 1. / (1000000);

--- a/private_set_intersection/cpp/psi_client.h
+++ b/private_set_intersection/cpp/psi_client.h
@@ -90,13 +90,22 @@ class PsiClient {
  public:
   PsiClient() = delete;
 
-  // Creates and returns a new client instance.
+  // Creates and returns a new client instance with a fresh private key.
   // If `reveal_intersection` is true, the client learns the elements in the
   // intersection of the two datasets. Otherwise, only the intersection size is
   // learned.
   //
   // Returns INTERNAL if any OpenSSL crypto operations fail.
-  static StatusOr<std::unique_ptr<PsiClient>> Create(bool reveal_intersection);
+  static StatusOr<std::unique_ptr<PsiClient>> CreateWithNewKey(bool reveal_intersection);
+
+  // Creates and returns a new client instance with the provided private key.
+  // If `reveal_intersection` is true, the client learns the elements in the
+  // intersection of the two datasets. Otherwise, only the intersection size is
+  // learned.
+  //
+  // Returns INTERNAL if any OpenSSL crypto operations fail.
+  static StatusOr<std::unique_ptr<PsiClient>> CreateFromKey(
+      const std::string& key_bytes, bool reveal_intersection);
 
   // Creates a request message to be sent to the server. For each input
   // element x, computes H(x)^c, where c is the secret key of ec_cipher_.
@@ -128,6 +137,10 @@ class PsiClient {
   StatusOr<int64_t> GetIntersectionSize(
       const std::string& server_setup,
       const std::string& server_response) const;
+
+  // Returns this instance's private key. This key should only be used to
+  // create other client instances. DO NOT SEND THIS KEY TO ANY OTHER PARTY!
+  std::string GetPrivateKeyBytes() const;
 
  private:
   explicit PsiClient(

--- a/private_set_intersection/cpp/psi_client.h
+++ b/private_set_intersection/cpp/psi_client.h
@@ -96,7 +96,8 @@ class PsiClient {
   // learned.
   //
   // Returns INTERNAL if any OpenSSL crypto operations fail.
-  static StatusOr<std::unique_ptr<PsiClient>> CreateWithNewKey(bool reveal_intersection);
+  static StatusOr<std::unique_ptr<PsiClient>> CreateWithNewKey(
+      bool reveal_intersection);
 
   // Creates and returns a new client instance with the provided private key.
   // If `reveal_intersection` is true, the client learns the elements in the

--- a/private_set_intersection/cpp/psi_client_test.cpp
+++ b/private_set_intersection/cpp/psi_client_test.cpp
@@ -33,7 +33,8 @@ namespace {
 class PsiClientTest : public ::testing::Test {
  protected:
   void SetUp(bool reveal_intersection) {
-    PSI_ASSERT_OK_AND_ASSIGN(client_, PsiClient::CreateWithNewKey(reveal_intersection));
+    PSI_ASSERT_OK_AND_ASSIGN(client_,
+                             PsiClient::CreateWithNewKey(reveal_intersection));
     PSI_ASSERT_OK_AND_ASSIGN(
         server_ec_cipher_,
         ::private_join_and_compute::ECCommutativeCipher::CreateWithNewKey(
@@ -121,12 +122,10 @@ TEST_F(PsiClientTest, TestCreatingFromKey) {
   }
 
   // Run client request.
-  PSI_ASSERT_OK_AND_ASSIGN(
-      auto client_request0,
-      client_->CreateRequest(client_elements));
-  PSI_ASSERT_OK_AND_ASSIGN(
-      auto client_request1,
-      client1->CreateRequest(client_elements));
+  PSI_ASSERT_OK_AND_ASSIGN(auto client_request0,
+                           client_->CreateRequest(client_elements));
+  PSI_ASSERT_OK_AND_ASSIGN(auto client_request1,
+                           client1->CreateRequest(client_elements));
 
   // Both requests should be the same
   EXPECT_EQ(client_request0, client_request1);
@@ -141,12 +140,10 @@ TEST_F(PsiClientTest, TestCreatingFromKey) {
                            PsiClient::CreateFromKey(key_bytes3, false));
 
   // Run client request.
-  PSI_ASSERT_OK_AND_ASSIGN(
-      auto client_request2,
-      client2->CreateRequest(client_elements));
-  PSI_ASSERT_OK_AND_ASSIGN(
-      auto client_request3,
-      client3->CreateRequest(client_elements));
+  PSI_ASSERT_OK_AND_ASSIGN(auto client_request2,
+                           client2->CreateRequest(client_elements));
+  PSI_ASSERT_OK_AND_ASSIGN(auto client_request3,
+                           client3->CreateRequest(client_elements));
   EXPECT_EQ(client_request2, client_request3);
 }
 

--- a/private_set_intersection/cpp/psi_server_test.cpp
+++ b/private_set_intersection/cpp/psi_server_test.cpp
@@ -41,7 +41,7 @@ TEST_F(PsiServerTest, TestCorrectnessIntersection) {
   SetUp(true);
   // We use an actual client instance here, since we already test the client
   // on its own in psi_client_test.cpp.
-  PSI_ASSERT_OK_AND_ASSIGN(auto client, PsiClient::Create(true));
+  PSI_ASSERT_OK_AND_ASSIGN(auto client, PsiClient::CreateWithNewKey(true));
   int num_client_elements = 1000, num_server_elements = 10000;
   double fpr = 0.01;
   std::vector<std::string> client_elements(num_client_elements);
@@ -90,7 +90,7 @@ TEST_F(PsiServerTest, TestCorrectnessIntersectionSize) {
   SetUp(false);
   // We use an actual client instance here, since we already test the client
   // on its own in psi_client_test.cpp.
-  PSI_ASSERT_OK_AND_ASSIGN(auto client, PsiClient::Create(false));
+  PSI_ASSERT_OK_AND_ASSIGN(auto client, PsiClient::CreateWithNewKey(false));
   int num_client_elements = 1000, num_server_elements = 10000;
   double fpr = 0.01;
   std::vector<std::string> client_elements(num_client_elements);
@@ -130,7 +130,7 @@ TEST_F(PsiServerTest, TestCorrectnessIntersectionSize) {
 
 TEST_F(PsiServerTest, TestArrayIsSortedWhenNotRevealingIntersection) {
   SetUp(false);
-  PSI_ASSERT_OK_AND_ASSIGN(auto client, PsiClient::Create(false));
+  PSI_ASSERT_OK_AND_ASSIGN(auto client, PsiClient::CreateWithNewKey(false));
   int num_client_elements = 1000;
   std::vector<std::string> client_elements(num_client_elements);
   for (int i = 0; i < num_client_elements; i++) {

--- a/private_set_intersection/go/README.md
+++ b/private_set_intersection/go/README.md
@@ -60,7 +60,7 @@ func main(){
         psiServer.Destroy()
     }
 
-    psiClient, err := client.Create(revealIntersection)
+    psiClient, err := client.CreateWithNewKey(revealIntersection)
     if err == nil  {
         fmt.Println("client loaded")
         psiClient.Destroy()

--- a/private_set_intersection/go/server/server_test.go
+++ b/private_set_intersection/go/server/server_test.go
@@ -83,7 +83,7 @@ func testServerFailure(t *testing.T, revealIntersection bool) {
 		t.Errorf("ProcessRequest should fail with an invalid input %v", err)
 	}
 
-	client, err := client.Create(!revealIntersection)
+	client, err := client.CreateWithNewKey(!revealIntersection)
 	if err != nil || client == nil {
 		t.Errorf("Failed to create a PSI client %v", err)
 	}
@@ -105,7 +105,7 @@ func TestServerFailure(t *testing.T) {
 }
 
 func testServerClient(t *testing.T, revealIntersection bool) {
-	client, err := client.Create(revealIntersection)
+	client, err := client.CreateWithNewKey(revealIntersection)
 	if err != nil || client == nil {
 		t.Errorf("Failed to create a PSI client %v", err)
 	}
@@ -226,7 +226,7 @@ func benchmarkServerProcessRequest(cnt int, revealIntersection bool, b *testing.
 	b.ReportAllocs()
 	total := 0
 	for n := 0; n < b.N; n++ {
-		client, err := client.Create(revealIntersection)
+		client, err := client.CreateWithNewKey(revealIntersection)
 		if err != nil || client == nil {
 			b.Errorf("failed to get client")
 		}

--- a/private_set_intersection/javascript/README.md
+++ b/private_set_intersection/javascript/README.md
@@ -21,7 +21,7 @@ import PSI from '@openmined/psi.js'
 const psi = await PSI()
 
 const server = psi.server.createWithNewKey()
-const client = psi.client.create()
+const client = psi.client.createWithNewKey()
 ```
 
 By **default**, the package will use the `combined` build with the `wasm` variant for getting started.
@@ -43,7 +43,7 @@ import PSI from '@openmined/psi.js/client/js/es'
 
 const psi = await PSI()
 
-const client = psi.client.create()
+const client = psi.client.createWithNewKey()
 // PSI.server is not implemented
 ```
 
@@ -76,7 +76,7 @@ import PSI from '@openmined/psi.js/combined/js/es'
 const psi = await PSI()
 
 const server = psi.server.createWithNewKey()
-const client = psi.client.create()
+const client = psi.client.createWithNewKey()
 ```
 
 ## Example
@@ -87,7 +87,7 @@ const psi = await PSI()
 
 // Create new server and client instances
 const server = psi.server.createWithNewKey()
-const client = psi.client.create()
+const client = psi.client.createWithNewKey()
 
 // Define mutually agreed upon parameters
 const fpr = 0.001 // false positive rate (0.1%)
@@ -97,13 +97,13 @@ const numTotalElements = 100 // Maximum size of the server set
 // Example server set of data
 const serverInputs = Array.from(
   { length: numTotalElements },
-  (_, i) => `Element ${i}`
+  (_, i) => `Element ${i * 2}`
 )
 
 // Example client set of data to check
 const clientInputs = Array.from(
   { length: numClientElements },
-  (_, i) => `Element ${i * 2}`
+  (_, i) => `Element ${i}`
 )
 
 // Create the setup message that will later

--- a/private_set_intersection/javascript/bindings/client.cpp
+++ b/private_set_intersection/javascript/bindings/client.cpp
@@ -9,14 +9,26 @@ EMSCRIPTEN_BINDINGS(PSI_Client) {
   using private_set_intersection::ToJSObject;
   using private_set_intersection::ToShared;
 
-  emscripten::register_vector<int32_t>("std::vector<int32_t>");
-
   emscripten::class_<PsiClient>("PsiClient")
       .smart_ptr<std::shared_ptr<PsiClient>>("std::shared_ptr<PsiClient>")
       .class_function(
-          "Create", optional_override([](bool reveal_intersection) {
-            return ToJSObject(ToShared(PsiClient::Create(reveal_intersection)));
+          "CreateWithNewKey", optional_override([](bool reveal_intersection) {
+            return ToJSObject(ToShared(PsiClient::CreateWithNewKey(reveal_intersection)));
           }))
+      .class_function("CreateFromKey",
+                      optional_override([](const emscripten::val &byte_array,
+                                           bool reveal_intersection) {
+                        const std::uint32_t l =
+                            byte_array["length"].as<std::uint32_t>();
+                        std::string byte_string(l, '\0');
+
+                        for (std::uint32_t i = 0; i < l; i++) {
+                          byte_string[i] = byte_array[i].as<std::uint8_t>();
+                        }
+
+                        return ToJSObject(ToShared(PsiClient::CreateFromKey(
+                            byte_string, reveal_intersection)));
+                      }))
       .function("CreateRequest",
                 optional_override([](const PsiClient& self,
                                      const emscripten::val& string_array) {
@@ -70,5 +82,14 @@ EMSCRIPTEN_BINDINGS(PSI_Client) {
                     result = status.status();
                   }
                   return ToJSObject(result);
-                }));
+                }))
+      .function(
+          "GetPrivateKeyBytes", optional_override([](const PsiClient &self) {
+            const std::string byte_string = self.GetPrivateKeyBytes();
+            const std::vector<std::uint8_t> byte_vector(byte_string.begin(),
+                                                        byte_string.end());
+            emscripten::val byte_array =
+                emscripten::val::array(byte_vector.begin(), byte_vector.end());
+            return byte_array;
+          }));
 }

--- a/private_set_intersection/javascript/bindings/client.cpp
+++ b/private_set_intersection/javascript/bindings/client.cpp
@@ -13,10 +13,11 @@ EMSCRIPTEN_BINDINGS(PSI_Client) {
       .smart_ptr<std::shared_ptr<PsiClient>>("std::shared_ptr<PsiClient>")
       .class_function(
           "CreateWithNewKey", optional_override([](bool reveal_intersection) {
-            return ToJSObject(ToShared(PsiClient::CreateWithNewKey(reveal_intersection)));
+            return ToJSObject(
+                ToShared(PsiClient::CreateWithNewKey(reveal_intersection)));
           }))
       .class_function("CreateFromKey",
-                      optional_override([](const emscripten::val &byte_array,
+                      optional_override([](const emscripten::val& byte_array,
                                            bool reveal_intersection) {
                         const std::uint32_t l =
                             byte_array["length"].as<std::uint32_t>();
@@ -84,7 +85,7 @@ EMSCRIPTEN_BINDINGS(PSI_Client) {
                   return ToJSObject(result);
                 }))
       .function(
-          "GetPrivateKeyBytes", optional_override([](const PsiClient &self) {
+          "GetPrivateKeyBytes", optional_override([](const PsiClient& self) {
             const std::string byte_string = self.GetPrivateKeyBytes();
             const std::vector<std::uint8_t> byte_vector(byte_string.begin(),
                                                         byte_string.end());

--- a/private_set_intersection/javascript/custom_types/psi-cardinality/index.d.ts
+++ b/private_set_intersection/javascript/custom_types/psi-cardinality/index.d.ts
@@ -55,6 +55,7 @@ declare module 'psi_*' {
       serverSetup: string,
       serverResponse: string
     ) => GetIntersectionSizeResult
+    readonly GetPrivateKeyBytes: () => Uint8Array
   }
 
   export type Package = {
@@ -81,7 +82,13 @@ declare module 'psi_*' {
     ) => GetIntersectionSizeResult
     readonly GetPrivateKeyBytes: () => Uint8Array
     readonly PsiClient: {
-      readonly Create: (revealIntersection: boolean) => CreateClientResult
+      readonly CreateWithNewKey: (
+        revealIntersection: boolean
+      ) => CreateClientResult
+      readonly CreateFromKey: (
+        key: Uint8Array,
+        revealIntersection: boolean
+      ) => CreateClientResult
     }
     readonly PsiServer: {
       readonly CreateWithNewKey: (

--- a/private_set_intersection/javascript/src/__tests__/client.test.ts
+++ b/private_set_intersection/javascript/src/__tests__/client.test.ts
@@ -8,16 +8,44 @@ beforeAll(async () => {
 })
 
 describe('PSI Client', () => {
+  test('It should create from an existing key', async () => {
+    const client1 = psi.client!.createWithNewKey()
+    const key = client1.getPrivateKeyBytes()
+
+    const client2 = psi.client!.createFromKey(key)
+
+    expect(client2.getPrivateKeyBytes()).toEqual(key)
+  })
+
+  test('It should fail to create from an invalid key', async () => {
+    const key = Uint8Array.from({ length: 32 })
+    expect(() => psi.client!.createFromKey(key)).toThrow()
+  })
   test('It should throw if deleted twice', async () => {
-    const client = psi.client!.create()
+    const client = psi.client!.createWithNewKey()
 
     client.delete()
 
     expect(client.delete).toThrowError(ERROR_INSTANCE_DELETED)
   })
 
+  test('It should return the private key as a binary array', async () => {
+    const client = psi.client!.createWithNewKey()
+    const keyLength = 32
+    const key = client.getPrivateKeyBytes()
+    expect(key.length).toBe(keyLength)
+  })
+
+  test('It should fail return the private key as a binary array if deleted', async () => {
+    const client = psi.client!.createWithNewKey()
+    client.delete()
+    expect(client.getPrivateKeyBytes.bind(client)).toThrowError(
+      ERROR_INSTANCE_DELETED
+    )
+  })
+
   test('It should create a request', async () => {
-    const client = psi.client!.create()
+    const client = psi.client!.createWithNewKey()
     const numClientElements = 10
     const clientInputs = Array.from(
       { length: numClientElements },
@@ -30,7 +58,7 @@ describe('PSI Client', () => {
   })
 
   test('It should throw if attempting to create a request after deletion', async () => {
-    const client = psi.client!.create()
+    const client = psi.client!.createWithNewKey()
     const numClientElements = 100
     const clientInputs = Array.from(
       { length: numClientElements },
@@ -45,7 +73,7 @@ describe('PSI Client', () => {
   })
 
   test('It should process a response (cardinality)', async () => {
-    const client = psi.client!.create()
+    const client = psi.client!.createWithNewKey()
     const serverSetup = JSON.stringify({
       // eslint-disable-next-line @typescript-eslint/camelcase
       num_hash_functions: 14,
@@ -72,7 +100,7 @@ describe('PSI Client', () => {
   })
 
   test('It should process a response (intersection)', async () => {
-    const client = psi.client!.create(true)
+    const client = psi.client!.createWithNewKey(true)
     const serverSetup = JSON.stringify({
       // eslint-disable-next-line @typescript-eslint/camelcase
       num_hash_functions: 14,
@@ -99,7 +127,7 @@ describe('PSI Client', () => {
   })
 
   test('It should throw if attempting to process a response after deletion (cardinality)', async () => {
-    const client = psi.client!.create()
+    const client = psi.client!.createWithNewKey()
     const serverSetup = JSON.stringify({
       // eslint-disable-next-line @typescript-eslint/camelcase
       num_hash_functions: 14,
@@ -129,7 +157,7 @@ describe('PSI Client', () => {
   })
 
   test('It should throw if attempting to process a response after deletion (intersection)', async () => {
-    const client = psi.client!.create(true)
+    const client = psi.client!.createWithNewKey(true)
     const serverSetup = JSON.stringify({
       // eslint-disable-next-line @typescript-eslint/camelcase
       num_hash_functions: 14,
@@ -159,7 +187,7 @@ describe('PSI Client', () => {
   })
 
   test('It should fail to process a response (cardinality)', async () => {
-    const client = psi.client!.create()
+    const client = psi.client!.createWithNewKey()
     const serverSetup = 'invalid'
     const serverResponse = 'invalid'
 
@@ -169,7 +197,7 @@ describe('PSI Client', () => {
   })
 
   test('It should fail to process a response (intersection)', async () => {
-    const client = psi.client!.create(true)
+    const client = psi.client!.createWithNewKey(true)
     const serverSetup = 'invalid'
     const serverResponse = 'invalid'
 

--- a/private_set_intersection/javascript/src/__tests__/integration.test.ts
+++ b/private_set_intersection/javascript/src/__tests__/integration.test.ts
@@ -8,7 +8,7 @@ beforeAll(async () => {
 
 describe('PSI Integration', () => {
   test('It should return the intersection', async () => {
-    const client = psi.client!.create(true)
+    const client = psi.client!.createWithNewKey(true)
     const key = Uint8Array.from(
       // eslint-disable-next-line no-undef
       Buffer.from('djY2Bgt4JwfbjvJn6dDzpwrTvKWVE1Ks458mlrd1/tY=', 'base64')
@@ -40,7 +40,7 @@ describe('PSI Integration', () => {
     expect(intersection.length).toBeLessThan((numClientElements / 2) * 1.1)
   })
   test('It should return the intersection size', async () => {
-    const client = psi.client!.create()
+    const client = psi.client!.createWithNewKey()
     const key = Uint8Array.from(
       // eslint-disable-next-line no-undef
       Buffer.from('djY2Bgt4JwfbjvJn6dDzpwrTvKWVE1Ks458mlrd1/tY=', 'base64')

--- a/private_set_intersection/javascript/src/implementation/psi.ts
+++ b/private_set_intersection/javascript/src/implementation/psi.ts
@@ -75,7 +75,7 @@ export const PSIConstructor = ({
      * @example
      * import PSI from '@openmined/psi.js'
      * const psi = await PSI()
-     * const client = psi.client.create()
+     * const client = psi.client.createWithNewKey()
      */
     ...(clientWrapper && { client: clientWrapper })
   }

--- a/private_set_intersection/python/tests.py
+++ b/private_set_intersection/python/tests.py
@@ -57,10 +57,10 @@ def test_server_sanity(reveal_intersection):
 
 @pytest.mark.parametrize("reveal_intersection", [False, True])
 def test_client_sanity(reveal_intersection):
-    s = psi.client.CreateWithNewKey(reveal_intersection)
-    assert s != None
+    c = psi.client.CreateWithNewKey(reveal_intersection)
+    assert c != None
 
-    key = s.GetPrivateKeyBytes()
+    key = c.GetPrivateKeyBytes()
     assert key != None
 
     other = psi.client.CreateFromKey(key, reveal_intersection)

--- a/private_set_intersection/python/tests.py
+++ b/private_set_intersection/python/tests.py
@@ -6,13 +6,13 @@ import private_set_intersection.python as psi
 
 @pytest.mark.parametrize("reveal_intersection", [False, True])
 def test_sanity(reveal_intersection):
-    c = psi.client.Create(reveal_intersection)
+    c = psi.client.CreateWithNewKey(reveal_intersection)
     assert c != None
 
 
 @pytest.mark.parametrize("reveal_intersection", [False, True])
 def test_client_server(reveal_intersection):
-    c = psi.client.Create(reveal_intersection)
+    c = psi.client.CreateWithNewKey(reveal_intersection)
     s = psi.server.CreateWithNewKey(reveal_intersection)
 
     client_items = ["Element " + str(i) for i in range(1000)]
@@ -43,7 +43,7 @@ def test_version():
 
 
 @pytest.mark.parametrize("reveal_intersection", [False, True])
-def test_sanity(reveal_intersection):
+def test_server_sanity(reveal_intersection):
     s = psi.server.CreateWithNewKey(reveal_intersection)
     assert s != None
 
@@ -55,10 +55,23 @@ def test_sanity(reveal_intersection):
 
     assert key == newkey
 
+@pytest.mark.parametrize("reveal_intersection", [False, True])
+def test_client_sanity(reveal_intersection):
+    s = psi.client.CreateWithNewKey(reveal_intersection)
+    assert s != None
+
+    key = s.GetPrivateKeyBytes()
+    assert key != None
+
+    other = psi.client.CreateFromKey(key, reveal_intersection)
+    newkey = other.GetPrivateKeyBytes()
+
+    assert key == newkey
+
 
 @pytest.mark.parametrize("reveal_intersection", [False, True])
 def test_server_client(reveal_intersection):
-    c = psi.client.Create(reveal_intersection)
+    c = psi.client.CreateWithNewKey(reveal_intersection)
     s = psi.server.CreateWithNewKey(reveal_intersection)
 
     client_items = ["Element " + str(i) for i in range(1000)]
@@ -85,7 +98,7 @@ def test_server_client(reveal_intersection):
 
 @pytest.mark.parametrize("reveal_intersection", [False, True])
 def test_empty_intersection(reveal_intersection):
-    c = psi.client.Create(reveal_intersection)
+    c = psi.client.CreateWithNewKey(reveal_intersection)
     s = psi.server.CreateWithNewKey(reveal_intersection)
 
     client_items = ["Element " + str(i) for i in range(1000)]

--- a/private_set_intersection/python/tests.py
+++ b/private_set_intersection/python/tests.py
@@ -55,6 +55,7 @@ def test_server_sanity(reveal_intersection):
 
     assert key == newkey
 
+
 @pytest.mark.parametrize("reveal_intersection", [False, True])
 def test_client_sanity(reveal_intersection):
     c = psi.client.CreateWithNewKey(reveal_intersection)


### PR DESCRIPTION
# Pull Request

## Description
Adds the ability to create a client instance using a previously generated private key.

Minor breaking change - `Client::Create` has been renamed to `Client::CreateWithNewKey` where applicable and the a new method is added `::CreateFromKey`, resembling the exact syntax for instantiating server instances.

## Affected Dependencies
List any dependencies that are required for this change.

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (non-breaking change which adds documentation)
- [x] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
Added tests to create client instances with a provided key.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have added tests for my changes

## Additional Context
Coverage:
- [x] CPP
- [x] CPP Tests
- [x] C
- [x] C Tests
- [x] Go
- [x] Go Tests
- [x] JavaScript
- [x] JavaScript Tests
- [x] Python
- [x] Python Tests