### PR TITLE
feat: removed cardinality verbiage, npm build now auto-updates version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![License](https://img.shields.io/github/license/OpenMined/PSI)
 ![OpenCollective](https://img.shields.io/opencollective/all/openmined)
 
-# PSI Cardinality
+# PSI
 
-Private Set Intersection Cardinality protocol based on ECDH and Bloom Filters.
+Private Set Intersection protocol based on ECDH and Bloom Filters.
 
 ## Requirements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,12 @@
 ## Caveats
-Several caveats should be carefully considered before using PSI-Cardinality.
+Several caveats should be carefully considered before using PSI.
 
 ### Information assumed public 
 1. Server set size
 2. Client set size
 (Note that Each of these can be turned into upper bounds by adding dummy elements.)
 
-### Security Limitations for the PSI-Cardinality protocol
+### Security Limitations for the PSI protocol
 
 Coordinated clients could get the actual intersection. However, server set items not
 in any of the client sets will never be uncovered.
@@ -30,7 +30,7 @@ your health authority only covers 10 possible geohashes, people could sidestep t
 entirely and submit location histories which unlock tests by brute force.
 
 
-A potential limitation with the PSI-cardinality approach is the communication complexity,
+A potential limitation with the PSI approach is the communication complexity,
 which scales linearly with the size of the larger set. This is of particular concern
 when performing PSI between a constrained device (cellphone) holding a small set, and a
 large service provider (e.g. WhatsApp), such as in the Private Contact Discovery application.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,34 +1,38 @@
 ## Caveats
+
 Several caveats should be carefully considered before using PSI.
 
-### Information assumed public 
+### Information assumed public
+
 1. Server set size
 2. Client set size
-(Note that Each of these can be turned into upper bounds by adding dummy elements.)
+   (Note that Each of these can be turned into upper bounds by adding dummy elements.)
 
 ### Security Limitations for the PSI protocol
 
-Coordinated clients could get the actual intersection. However, server set items not
+There are two configurations for instantiating a new client/server pair by passing in a boolean switch into their respective constructors.
+
+1. One that reveals only the **size** (cardinality) of the intersection to the client.
+2. One that reveals the actual **intersecion** to the client.
+
+In the case of #1, coordinated clients could get the actual intersection. However, server set items not
 in any of the client sets will never be uncovered.
 Situations where it’s feasible for clients to send one request per element in the domain -
 there is a possbility that coordinated clients could uncover server set. A larger set means
 more bits turned on in bloom filter.
 
-
 Presence of new client set members or absence of former client set members can be
 detected by server/eavesdroppers if client secret is reused.
 
-
 In the absence of any rate limiting and assuming the client and server have enough
 computing power and bandwidth, small domains may be brute-forceable. However, a query
-needs to be  performed for each brute-force attempt.
-An example for this situation would be suppose you were trying to limit sending antibody 
+needs to be performed for each brute-force attempt.
+An example for this situation would be suppose you were trying to limit sending antibody
 tests to people based on whether they’d been in an infected location, so that people would
 have to share their location history to prove they’d been somewhere infected, and you were
 using PSI so people wouldn’t have to share their location history without good reason. If
 your health authority only covers 10 possible geohashes, people could sidestep the PSI step
 entirely and submit location histories which unlock tests by brute force.
-
 
 A potential limitation with the PSI approach is the communication complexity,
 which scales linearly with the size of the larger set. This is of particular concern

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmined/psi.js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "keywords": [
     "psi",
+    "psi.js",
     "private set intersection",
     "private join and compute"
   ],
@@ -35,7 +36,7 @@
     "build:benchmark:js": "bash private_set_intersection/javascript/scripts/build-benchmark-js.sh && npm run build:copy",
     "build:benchmark:wasm": "bash private_set_intersection/javascript/scripts/build-benchmark-wasm.sh && npm run build:copy",
     "build:copy": "bash private_set_intersection/javascript/scripts/build-copy.sh",
-    "postbuild": "node private_set_intersection/javascript/version.js",
+    "postbuild": "node -r esm private_set_intersection/javascript/version.js",
     "prerollup": "bash private_set_intersection/javascript/scripts/prerollup.sh",
     "rollup": "rollup -c",
     "postrollup": "bash private_set_intersection/javascript/scripts/postrollup.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmined/psi.js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Private Set Intersection for JavaScript",
   "repository": {
     "type": "git",
@@ -35,6 +35,7 @@
     "build:benchmark:js": "bash private_set_intersection/javascript/scripts/build-benchmark-js.sh && npm run build:copy",
     "build:benchmark:wasm": "bash private_set_intersection/javascript/scripts/build-benchmark-wasm.sh && npm run build:copy",
     "build:copy": "bash private_set_intersection/javascript/scripts/build-copy.sh",
+    "postbuild": "node private_set_intersection/javascript/version.js",
     "prerollup": "bash private_set_intersection/javascript/scripts/prerollup.sh",
     "rollup": "rollup -c",
     "postrollup": "bash private_set_intersection/javascript/scripts/postrollup.sh",

--- a/private_set_intersection/cpp/README.md
+++ b/private_set_intersection/cpp/README.md
@@ -1,6 +1,6 @@
-# PSI Cardinality - C++
+# PSI - C++
 
-Private Set Intersection Cardinality protocol based on ECDH and Bloom Filters.
+Private Set Intersection protocol based on ECDH and Bloom Filters.
 
 ## Build and test
 

--- a/private_set_intersection/cpp/psi_client.h
+++ b/private_set_intersection/cpp/psi_client.h
@@ -25,12 +25,12 @@ namespace private_set_intersection {
 
 using ::private_join_and_compute::StatusOr;
 
-// Client side of a Private Set Intersection-Cardinality protocol. In
-// PSI-Cardinality, two parties (client and server) each hold a dataset, and at
+// Client side of a Private Set Intersection protocol. In
+// PSI, two parties (client and server) each hold a dataset, and at
 // the end of the protocol the client learns the size of the intersection of
-// both datasets, while no party learns anything beyond that.
+// both datasets, while no party learns anything beyond that (cardinality mode).
 //
-// This variant of PSI-Cardinality introduces a small false-positive rate (i.e.,
+// This variant of PSI introduces a small false-positive rate (i.e.,
 // the reported cardinality will be slightly larger than the actual cardinality.
 // The false positive rate can be tuned by the server.
 //

--- a/private_set_intersection/cpp/psi_server.h
+++ b/private_set_intersection/cpp/psi_server.h
@@ -25,7 +25,7 @@ namespace private_set_intersection {
 
 using ::private_join_and_compute::StatusOr;
 
-// The server side of a Private Set Intersection Cardinality protocol.
+// The server side of a Private Set Intersection protocol.
 // See the documentation in PsiClient for a full description of the
 // protocol.
 class PsiServer {

--- a/private_set_intersection/go/client/client.go
+++ b/private_set_intersection/go/client/client.go
@@ -2,7 +2,7 @@
 //
 // In PSI, two parties (client and server) each hold a dataset, and at
 // the end of the protocol the client learns the size of the intersection of
-// both datasets, while no party learns anything beyond that.
+// both datasets, while no party learns anything beyond that (cardinality mode).
 //
 // This variant of PSI introduces a small false-positive rate (i.e.,
 // the reported cardinality will be slightly larger than the actual cardinality.

--- a/private_set_intersection/go/server/server.go
+++ b/private_set_intersection/go/server/server.go
@@ -2,7 +2,7 @@
 //
 // In PSI, two parties (client and server) each hold a dataset, and at
 // the end of the protocol the client learns the size of the intersection of
-// both datasets, while no party learns anything beyond that.
+// both datasets, while no party learns anything beyond that (cardinality mode).
 //
 // This variant of PSI introduces a small false-positive rate (i.e.,
 // the reported cardinality will be slightly larger than the actual cardinality.

--- a/private_set_intersection/javascript/README.md
+++ b/private_set_intersection/javascript/README.md
@@ -1,6 +1,6 @@
-# PSI Cardinality - JavaScript
+# PSI - JavaScript
 
-Private Set Intersection Cardinality protocol based on ECDH and Bloom Filters.
+Private Set Intersection protocol based on ECDH and Bloom Filters.
 
 ## Installing
 

--- a/private_set_intersection/javascript/README.md
+++ b/private_set_intersection/javascript/README.md
@@ -6,7 +6,7 @@
 
 # PSI - JavaScript
 
-Private Set Intersection protocol based on ECDH and Bloom Filters. The goal of this library is to allow a server to compute the intersection or intersection size (cardinality) from a set on the server and a set from a client without the server learning anything about the client's set.
+Private Set Intersection protocol based on ECDH and Bloom Filters. The goal of this library is to allow a server to compute and return the intersection or intersection size (cardinality) from a set on the server and a set from a client without the server learning anything about the client's set.
 
 - 💾 Low memory footprint
 - 🚀 Fastest implementation using WebAssembly

--- a/private_set_intersection/javascript/README.md
+++ b/private_set_intersection/javascript/README.md
@@ -1,8 +1,19 @@
+![om-logo](https://github.com/OpenMined/design-assets/blob/master/logos/OM/horizontal-primary-trans.png)
+
+[![Tests](https://github.com/OpenMined/PSI/workflows/Tests/badge.svg?branch=master&event=push)](https://github.com/OpenMined/PSI/actions?query=workflow%3ATests+branch%3Amaster+event%3Apush)
+![License](https://img.shields.io/github/license/OpenMined/PSI)
+![OpenCollective](https://img.shields.io/opencollective/all/openmined)
+
 # PSI - JavaScript
 
-Private Set Intersection protocol based on ECDH and Bloom Filters.
+Private Set Intersection protocol based on ECDH and Bloom Filters. The goal of this library is to allow a server to compute the intersection or intersection size (cardinality) from a set on the server and a set from a client without the server learning anything about the client's set.
 
-## Installing
+- 💾 Low memory footprint
+- 🚀 Fastest implementation using WebAssembly
+- 🔥 Works in any client / server configuration
+- 😎 Privacy preserving
+
+## Installation
 
 To install, run:
 
@@ -12,39 +23,39 @@ npm install @openmined/psi.js
 yarn add @openmined/psi.js
 ```
 
-Then import the package:
+## Usage
+
+Then `import` or `require` the package:
 
 ```javascript
 import PSI from '@openmined/psi.js'
-
-// Wait for the library to initialize
-const psi = await PSI()
-
-const server = psi.server.createWithNewKey()
-const client = psi.client.createWithNewKey()
+// or
+const PSI = require('@openmined/psi.js')
 ```
 
-By **default**, the package will use the `combined` build with the `wasm` variant for getting started.
-This includes both `client` and `server` implementations, but often only one is used. We offer deep import
+By **default**, the package will use the `combined` build with the `wasm` target using the `umd` variant. This includes both `client` and `server` implementations, but often only one is used. We offer deep import
 links to only load what is needed for your specific environment.
 
 The deep import structure is as follows:
-`<package name>/<client|server|combined>/<wasm|js>/<umd|es>`
+`<package name> / <client|server|combined> / <wasm|js> / <umd|es>`
 
 To only load the `client`:
 
 ```javascript
 // Loads only the client, supporting WebAssembly or asm.js
 // with either `umd` (Browser + NodeJS) or `es` (ES6 modules)
+// Pick one of the following:
 import PSI from '@openmined/psi.js/client/wasm/umd'
 import PSI from '@openmined/psi.js/client/wasm/es'
 import PSI from '@openmined/psi.js/client/js/umd'
 import PSI from '@openmined/psi.js/client/js/es'
+;(async () => {
+  // Wait for the library to initialize
+  const psi = await PSI()
 
-const psi = await PSI()
-
-const client = psi.client.createWithNewKey()
-// PSI.server is not implemented
+  const client = psi.client.createWithNewKey()
+  // psi.server is not implemented
+})()
 ```
 
 To only load the `server`:
@@ -52,80 +63,148 @@ To only load the `server`:
 ```javascript
 // Loads only the server, supporting WebAssembly or asm.js
 // with either `umd` (Browser + NodeJS) or `es` (ES6 modules)
+// Pick one of the following:
 import PSI from '@openmined/psi.js/server/wasm/umd'
 import PSI from '@openmined/psi.js/server/wasm/es'
 import PSI from '@openmined/psi.js/server/js/umd'
 import PSI from '@openmined/psi.js/server/js/es'
+;(async () => {
+  // Wait for the library to initialize
+  const psi = await PSI()
 
-const psi = await PSI()
-
-const server = psi.server.createWithNewKey()
-// PSI.client is not implemented
+  const server = psi.server.createWithNewKey()
+  // psi.client is not implemented
+})()
 ```
 
-To **manually** load the `combined`:
+To **manually** override load the `combined` default import:
 
 ```javascript
 // Loads the combined server and client, supporting WebAssembly or asm.js
 // with either `umd` (Browser + NodeJS) or `es` (ES6 modules)
-import PSI from '@openmined/psi.js/combined/wasm/umd'
+// Pick one of the following:
+import PSI from '@openmined/psi.js/combined/wasm/umd' // Default
 import PSI from '@openmined/psi.js/combined/wasm/es'
 import PSI from '@openmined/psi.js/combined/js/umd'
 import PSI from '@openmined/psi.js/combined/js/es'
+;(async () => {
+  // Wait for the library to initialize
+  const psi = await PSI()
 
-const psi = await PSI()
-
-const server = psi.server.createWithNewKey()
-const client = psi.client.createWithNewKey()
+  const client = psi.client.createWithNewKey()
+  const server = psi.server.createWithNewKey()
+})()
 ```
 
-## Example
+## Example (intersection size)
 
 ```javascript
-import PSI from '@openmined/psi.js'
-const psi = await PSI()
+const PSI = require('@openmined/psi.js')
 
-// Create new server and client instances
-const server = psi.server.createWithNewKey()
-const client = psi.client.createWithNewKey()
+;(async () => {
+  const psi = await PSI()
 
-// Define mutually agreed upon parameters
-const fpr = 0.001 // false positive rate (0.1%)
-const numClientElements = 10 // Size of the client set to check
-const numTotalElements = 100 // Maximum size of the server set
+  // Create new server and client instances
+  const server = psi.server.createWithNewKey()
+  const client = psi.client.createWithNewKey()
 
-// Example server set of data
-const serverInputs = Array.from(
-  { length: numTotalElements },
-  (_, i) => `Element ${i * 2}`
-)
+  // Define mutually agreed upon parameters
+  const fpr = 0.001 // false positive rate (0.1%)
+  const numClientElements = 10 // Size of the client set to check
+  const numTotalElements = 100 // Maximum size of the server set
 
-// Example client set of data to check
-const clientInputs = Array.from(
-  { length: numClientElements },
-  (_, i) => `Element ${i}`
-)
+  // Example server set of data
+  const serverInputs = Array.from(
+    { length: numTotalElements },
+    (_, i) => `Element ${i * 2}`
+  )
 
-// Create the setup message that will later
-// be used to compute the intersection. Send to client
-const serverSetup = server.createSetupMessage(
-  fpr,
-  numClientElements,
-  serverInputs
-)
+  // Example client set of data to check
+  const clientInputs = Array.from(
+    { length: numClientElements },
+    (_, i) => `Element ${i}`
+  )
 
-// Create a client request to send to the server
-const clientRequest = client.createRequest(clientInputs)
+  // Create the setup message that will later
+  // be used to compute the intersection. Send to client
+  const serverSetup = server.createSetupMessage(
+    fpr,
+    numClientElements,
+    serverInputs
+  )
 
-// Process the client's request and return to the client
-const serverResponse = server.processRequest(clientRequest)
+  // Create a client request to send to the server
+  const clientRequest = client.createRequest(clientInputs)
 
-// Client computes the intersection and the server has learned nothing!
-const intersection = client.getIntersection(serverSetup, serverResponse)
-// intersection = 10
+  // Process the client's request and return to the client
+  const serverResponse = server.processRequest(clientRequest)
+
+  // Client computes the intersection cardinality
+  // and the server has learned nothing!
+  const intersection = client.getIntersectionSize(serverSetup, serverResponse)
+  // intersection = 5
+})()
 ```
 
-## Compiling and Running
+## Example (intersection)
+
+```javascript
+const PSI = require('@openmined/psi.js')
+
+;(async () => {
+  const psi = await PSI()
+
+  // Create new server and client instances
+  const server = psi.server.createWithNewKey(true)
+  const client = psi.client.createWithNewKey(true)
+
+  // Define mutually agreed upon parameters
+  const fpr = 0.001 // false positive rate (0.1%)
+  const numClientElements = 10 // Size of the client set to check
+  const numTotalElements = 100 // Maximum size of the server set
+
+  // Example server set of data
+  const serverInputs = Array.from(
+    { length: numTotalElements },
+    (_, i) => `Element ${i * 2}`
+  )
+
+  // Example client set of data to check
+  const clientInputs = Array.from(
+    { length: numClientElements },
+    (_, i) => `Element ${i}`
+  )
+
+  // Create the setup message that will later
+  // be used to compute the intersection. Send to client
+  const serverSetup = server.createSetupMessage(
+    fpr,
+    numClientElements,
+    serverInputs
+  )
+
+  // Create a client request to send to the server
+  const clientRequest = client.createRequest(clientInputs)
+
+  // Process the client's request and return to the client
+  const serverResponse = server.processRequest(clientRequest)
+
+  // Client computes the intersection cardinality
+  // and the server has learned nothing!
+  const intersection = client.getIntersection(serverSetup, serverResponse)
+  // intersection [ 0, 2, 4, 6, 8 ]
+})()
+```
+
+## Contributors
+
+See [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
+## Contributing
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Please make sure to update tests as appropriate.
 
 ### Requirements
 
@@ -156,11 +235,6 @@ npm install
 To build the client, server, or combined (both client and server) for WebAssembly and pure JS
 
 ```
-npm run build:client
-npm run build:server
-npm run build:combined
-
-# or all three
 npm run build
 ```
 
@@ -169,19 +243,15 @@ Run the tests or generate coverage reports. **Note** tests are run using the WAS
 ```
 npm run test
 
-# or to see coverage
+# or to test and see coverage
 npm run coverage
 ```
 
-## Benchmarks
+### Benchmarks
 
-Build the benchmark for WebAssembly, pure JS, or both variants
+Build the benchmark for WebAssembly and pure JS
 
 ```
-npm run build:benchmark:wasm
-npm run build:benchmark:js
-
-# or both
 npm run build:benchmark
 ```
 
@@ -192,7 +262,7 @@ npm run benchmark:wasm
 npm run benchmark:js
 ```
 
-## Publishing
+### Publishing
 
 Ensure we start with a clean build
 
@@ -235,3 +305,7 @@ Finally, publish the bundle
 Instead, we have a custom override which will publish the npm package from a specific directory.
 This allows us to publish a single package with shortened deep import links that specify the
 different targets listed above.
+
+## License
+
+[Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/)

--- a/private_set_intersection/javascript/src/implementation/psi.ts
+++ b/private_set_intersection/javascript/src/implementation/psi.ts
@@ -42,7 +42,7 @@ export const PSIConstructor = ({
 
     /**
      * @description
-     * The server side of a Private Set Intersection Cardinality protocol.
+     * The server side of a Private Set Intersection protocol.
      * See the documentation in PSI.Client for a full description of the
      * protocol.
      *
@@ -59,12 +59,12 @@ export const PSIConstructor = ({
 
     /**
      * @description
-     * Client side of a Private Set Intersection-Cardinality protocol. In
-     * PSI-Cardinality, two parties (client and server) each hold a dataset, and at
+     * Client side of a Private Set Intersection protocol. In
+     * PSI, two parties (client and server) each hold a dataset, and at
      * the end of the protocol the client learns the size of the intersection of
      * both datasets, while no party learns anything beyond that.
      *
-     * This variant of PSI-Cardinality introduces a small false-positive rate (i.e.,
+     * This variant of PSI introduces a small false-positive rate (i.e.,
      * the reported cardinality will be slightly larger than the actual cardinality.
      * The false positive rate can be tuned by the server.
      *

--- a/private_set_intersection/javascript/src/implementation/server.ts
+++ b/private_set_intersection/javascript/src/implementation/server.ts
@@ -108,7 +108,7 @@ const ServerConstructor = (instance: psi.Server): Server => {
      * @function
      * @name Server#processRequest
      * @param {String} clientRequest The serialized client request
-     * @returns {String} The PSI cardinality
+     * @returns {String} The PSI cardinality or size
      */
     processRequest(clientRequest: string): string {
       if (!_instance) {
@@ -145,7 +145,7 @@ export const ServerWrapperConstructor = ({
 
   return {
     /**
-     * Create a new PSI Cardinality server
+     * Create a new PSI server
      *
      * @function
      * @name Server.createWithNewKey
@@ -163,7 +163,7 @@ export const ServerWrapperConstructor = ({
       return ServerConstructor(Value)
     },
     /**
-     * Create a new PSI Cardinality server from a key
+     * Create a new PSI server from a key
      *
      * @function
      * @name Server.createFromKey

--- a/private_set_intersection/javascript/version.js
+++ b/private_set_intersection/javascript/version.js
@@ -18,7 +18,7 @@ import npmPackageLock from '../../package-lock.json'
   console.log('Updating package version to:', version)
   npmPackage.version = version
   npmPackageLock.version = version
-  const updatedPackage = JSON.stringify(npmPackage, null, 2)
+  const updatedPackage = JSON.stringify(npmPackage, null, 2) + '\n'
   const updatedPackageLock = JSON.stringify(npmPackageLock, null, 2)
   writeFileSync('package.json', updatedPackage)
   writeFileSync('package-lock.json', updatedPackageLock)

--- a/private_set_intersection/javascript/version.js
+++ b/private_set_intersection/javascript/version.js
@@ -1,12 +1,25 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const PSI = require('./dist/combined/js/umd')
-const fs = require('fs')
-const package = require('../../package.json')
-
+/**
+ * This file is strictly used to update the version value inside package.json
+ *
+ * It calls the direct output from the emscripten build and therefore
+ * does not use the wrappers in TS. This is not ideal, however
+ * it is designed to update the version at build time in order to trigger
+ * the need for a commit before bundling.
+ */
+import PSI from './bin/psi_combined_wasm.js'
+import { writeFileSync } from 'fs'
+import npmPackage from '../../package.json'
+import npmPackageLock from '../../package-lock.json'
 ;(async () => {
   const psi = await PSI()
-  package.version = psi.package.version
-  console.log('Updating package version to:', package.version)
-  const updatedPackage = JSON.stringify(package, null, 2)
-  fs.writeFileSync('package.json', updatedPackage)
+  // Ensure we don't null this field.
+  const version = psi.Package.version() || npmPackage.version
+  // eslint-disable-next-line no-undef
+  console.log('Updating package version to:', version)
+  npmPackage.version = version
+  npmPackageLock.version = version
+  const updatedPackage = JSON.stringify(npmPackage, null, 2)
+  const updatedPackageLock = JSON.stringify(npmPackageLock, null, 2)
+  writeFileSync('package.json', updatedPackage)
+  writeFileSync('package-lock.json', updatedPackageLock)
 })()

--- a/private_set_intersection/javascript/version.js
+++ b/private_set_intersection/javascript/version.js
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const PSI = require('./dist/combined/js/umd')
+const fs = require('fs')
+const package = require('../../package.json')
+
+;(async () => {
+  const psi = await PSI()
+  package.version = psi.package.version
+  console.log('Updating package version to:', package.version)
+  const updatedPackage = JSON.stringify(package, null, 2)
+  fs.writeFileSync('package.json', updatedPackage)
+})()

--- a/private_set_intersection/python/README.md
+++ b/private_set_intersection/python/README.md
@@ -1,6 +1,6 @@
-# PSI Cardinality - Python
+# PSI - Python
 
-Private Set Intersection Cardinality protocol based on ECDH and Bloom Filters.
+Private Set Intersection protocol based on ECDH and Bloom Filters.
 
 ## Tests
 ```

--- a/private_set_intersection/python/__init__.py
+++ b/private_set_intersection/python/__init__.py
@@ -1,4 +1,4 @@
-"""Private Set Intersection Cardinality protocol based on ECDH and Bloom
+"""Private Set Intersection protocol based on ECDH and Bloom
 Filters.
 """
 from private_set_intersection.python import _psi_bindings

--- a/private_set_intersection/python/psi_bindings.cpp
+++ b/private_set_intersection/python/psi_bindings.cpp
@@ -23,7 +23,7 @@ T throwOrReturn(const private_join_and_compute::StatusOr<T>& in) {
 
 PYBIND11_MODULE(_psi_bindings, m) {
   m.doc() =
-      "Private Set Intersection Cardinality protocol based on ECDH and Bloom "
+      "Private Set Intersection protocol based on ECDH and Bloom "
       "Filters";
 
   m.attr("__version__") = ::private_set_intersection::Package::kVersion;

--- a/tools/package.bzl
+++ b/tools/package.bzl
@@ -1,2 +1,2 @@
 """ Version of the current release """
-VERSION_LABEL = "0.1.0"
+VERSION_LABEL = "0.1.1"


### PR DESCRIPTION
## Description
Removed some usages of the word `cardinality` where it didn't make sense. Added a post build step to auto update the package.json version value.

## Affected Dependencies
N/A

## How has this been tested?
- CI tests pass

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
