### PR TITLE
Use protoc from Bazel when building for JS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,6 @@ jobs:
         os: [macos-latest, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        uses: arduino/setup-protoc@master
-        with:
-          version: '3.12.x'
       - name: Run tests
         timeout-minutes: 30
         run: .github/workflows/scripts/run_tests_js.sh

--- a/private_set_intersection/javascript/scripts/build-proto.sh
+++ b/private_set_intersection/javascript/scripts/build-proto.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Path to this plugin
+# Path to this plugin.
 PROTOC_GEN_TS_PATH="./node_modules/.bin/protoc-gen-ts"
 
-# Directory to write generated code to (.js and .d.ts files)
+# Directory to write generated code to (.js and .d.ts files).
 OUT_DIR_JS="./private_set_intersection/javascript/bin"
 OUT_DIR_TS="./private_set_intersection/javascript/src/implementation/proto"
 
 PROTO_DIR="./private_set_intersection/proto"
 
-protoc \
+# Build the protobuf compiler.
+bazel build -c opt --platforms="@local_config_platform//:host" @com_google_protobuf//:protoc
+PROTOC_BINARY="./bazel-bin/external/com_google_protobuf/protoc"
+
+"$PROTOC_BINARY" \
     --plugin="protoc-gen-ts=${PROTOC_GEN_TS_PATH}" \
     --proto_path="${PROTO_DIR}" \
     --js_out="import_style=commonjs,binary:${OUT_DIR_JS}" \


### PR DESCRIPTION
This builds `protoc` using Bazel instead of installing it in CI builds, hopefully fixing [rate limiting issues](https://github.com/OpenMined/PSI/pull/68/checks?check_run_id=822392008).