### PR TITLE
Update pybind11_bazel version and fix checksum

### DIFF
--- a/private_set_intersection/deps.bzl
+++ b/private_set_intersection/deps.bzl
@@ -97,7 +97,7 @@ def psi_deps():
     py_repositories()
 
     # Configure python3 for pybind11.
-    python_configure(name = "local_config_python", python3 = True)
+    python_configure(name = "local_config_python", python_version = "3")
 
     # Install pip requirements for Python tests.
     rules_python_external_dependencies()

--- a/private_set_intersection/preload.bzl
+++ b/private_set_intersection/preload.bzl
@@ -65,9 +65,9 @@ def psi_preload():
     if "pybind11_bazel" not in native.existing_rules():
         http_archive(
             name = "pybind11_bazel",
-            strip_prefix = "pybind11_bazel-py3",
-            urls = ["https://github.com/kerrick-lyft/pybind11_bazel/archive/py3.zip"],
-            sha256 = "7b45a217ad57a50698ff83ca36fce37ebbd17502d429bd1e78bfacb66bab17dc",
+            strip_prefix = "pybind11_bazel-203508e14aab7309892a1c5f7dd05debda22d9a5",
+            urls = ["https://github.com/pybind/pybind11_bazel/archive/203508e14aab7309892a1c5f7dd05debda22d9a5.zip"],
+            sha256 = "75922da3a1bdb417d820398eb03d4e9bd067c4905a4246d35a44c01d62154d91",
         )
 
     if "pybind11" not in native.existing_rules():


### PR DESCRIPTION
## Description
Updates the pybind11_bazel version to the upstream repo as https://github.com/pybind/pybind11_bazel/pull/17 has been merged. Fixes #72.

## Affected Dependencies
None

## How has this been tested?
`bazel test`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
