### PR TITLE
Only compile python bindings with C++17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,3 @@
-##### Global #####
-# Needed for python (pybind11) bindings
-build --cxxopt=--std=c++17
-
 ##### WASM #####
 # Use our custom-configured c++ toolchain.
 build:wasm --crosstool_top=//private_set_intersection/javascript/toolchain:emscripten

--- a/private_set_intersection/c/psi_client_test.cpp
+++ b/private_set_intersection/c/psi_client_test.cpp
@@ -92,8 +92,7 @@ void test_corectness(bool reveal_intersection) {
   ASSERT_TRUE(request_proto.ParseFromArray(client_request, req_len));
 
   // Re-encrypt elements.
-  const google::protobuf::RepeatedPtrField encrypted_elements =
-      request_proto.encrypted_elements();
+  const auto &encrypted_elements = request_proto.encrypted_elements();
 
   // Create the response
   psi_proto::Response response;

--- a/private_set_intersection/cpp/psi_client.cpp
+++ b/private_set_intersection/cpp/psi_client.cpp
@@ -122,8 +122,7 @@ StatusOr<std::vector<int64_t>> PsiClient::ProcessResponse(
   ASSIGN_OR_RETURN(auto bloom_filter,
                    BloomFilter::CreateFromProtobuf(server_setup));
 
-  const google::protobuf::RepeatedPtrField response_array =
-      server_response.encrypted_elements();
+  const auto& response_array = server_response.encrypted_elements();
   const std::int64_t response_size =
       static_cast<std::int64_t>(response_array.size());
   std::vector<int64_t> result(0);

--- a/private_set_intersection/cpp/psi_client_test.cpp
+++ b/private_set_intersection/cpp/psi_client_test.cpp
@@ -41,7 +41,7 @@ class PsiClientTest : public ::testing::Test {
 
   void CreateDummySetupMessage(absl::Span<const std::string> server_elements,
                                double fpr,
-                               psi_proto::ServerSetup *server_setup) {
+                               psi_proto::ServerSetup* server_setup) {
     auto num_server_elements = static_cast<int64_t>(server_elements.size());
     // Insert server elements into Bloom filter.
     PSI_ASSERT_OK_AND_ASSIGN(auto bloom_filter,
@@ -54,16 +54,15 @@ class PsiClientTest : public ::testing::Test {
     *server_setup = bloom_filter->ToProtobuf();
   }
 
-  void CreateDummyResponse(const psi_proto::Request &client_request,
-                           psi_proto::Response *server_response) {
+  void CreateDummyResponse(const psi_proto::Request& client_request,
+                           psi_proto::Response* server_response) {
     ASSERT_TRUE(client_request.IsInitialized());
     ASSERT_TRUE(server_response->IsInitialized());
 
     // Clear the elements
     server_response->clear_encrypted_elements();
 
-    const google::protobuf::RepeatedPtrField encrypted_elements =
-        client_request.encrypted_elements();
+    const auto& encrypted_elements = client_request.encrypted_elements();
     const std::int64_t num_request_elements =
         static_cast<std::int64_t>(encrypted_elements.size());
 
@@ -110,10 +109,8 @@ TEST_F(PsiClientTest, TestCreatingFromKey) {
   // Both requests should be the same
   EXPECT_EQ(client_request0.reveal_intersection(),
             client_request1.reveal_intersection());
-  const google::protobuf::RepeatedPtrField elements0 =
-      client_request0.encrypted_elements();
-  const google::protobuf::RepeatedPtrField elements1 =
-      client_request1.encrypted_elements();
+  const auto& elements0 = client_request0.encrypted_elements();
+  const auto& elements1 = client_request1.encrypted_elements();
   ASSERT_TRUE(elements0.size() == elements1.size());
   for (int i = 0; i < elements0.size(); i++) {
     EXPECT_EQ(elements0[i], elements1[i]);
@@ -135,10 +132,8 @@ TEST_F(PsiClientTest, TestCreatingFromKey) {
                            client3->CreateRequest(client_elements));
   EXPECT_EQ(client_request2.reveal_intersection(),
             client_request3.reveal_intersection());
-  const google::protobuf::RepeatedPtrField elements2 =
-      client_request0.encrypted_elements();
-  const google::protobuf::RepeatedPtrField elements3 =
-      client_request1.encrypted_elements();
+  const auto& elements2 = client_request0.encrypted_elements();
+  const auto& elements3 = client_request1.encrypted_elements();
   ASSERT_TRUE(elements2.size() == elements3.size());
   for (int i = 0; i < elements2.size(); i++) {
     EXPECT_EQ(elements2[i], elements3[i]);

--- a/private_set_intersection/cpp/psi_server.cpp
+++ b/private_set_intersection/cpp/psi_server.cpp
@@ -94,8 +94,7 @@ StatusOr<psi_proto::Response> PsiServer::ProcessRequest(
   }
 
   // Re-encrypt elements.
-  const google::protobuf::RepeatedPtrField encrypted_elements =
-      client_request.encrypted_elements();
+  const auto& encrypted_elements = client_request.encrypted_elements();
   const std::int64_t num_client_elements =
       static_cast<std::int64_t>(encrypted_elements.size());
 
@@ -112,14 +111,9 @@ StatusOr<psi_proto::Response> PsiServer::ProcessRequest(
   // sort the resulting ciphertexts if we want to hide the intersection from the
   // client.
   if (!reveal_intersection) {
-    const google::protobuf::RepeatedPtrField elements =
-        response.encrypted_elements();
-    // Create a copy to mutate
-    google::protobuf::RepeatedPtrField sorted_elements = elements;
-    std::sort(sorted_elements.begin(), sorted_elements.end());
-    for (int i = 0; i < num_client_elements; i++) {
-      response.set_encrypted_elements(i, sorted_elements[i]);
-    }
+    // Get mutable reference to encrypted_elements array and sort it.
+    auto& elements = *(response.mutable_encrypted_elements());
+    std::sort(elements.begin(), elements.end());
   }
   return response;
 }

--- a/private_set_intersection/cpp/psi_server_test.cpp
+++ b/private_set_intersection/cpp/psi_server_test.cpp
@@ -145,8 +145,7 @@ TEST_F(PsiServerTest, TestArrayIsSortedWhenNotRevealingIntersection) {
                            server_->ProcessRequest(client_request));
 
   ASSERT_TRUE(server_response.IsInitialized());
-  const google::protobuf::RepeatedPtrField response_array =
-      server_response.encrypted_elements();
+  const auto& response_array = server_response.encrypted_elements();
   EXPECT_TRUE(std::is_sorted(response_array.begin(), response_array.end()));
 }
 

--- a/private_set_intersection/javascript/src/__tests__/client.test.ts
+++ b/private_set_intersection/javascript/src/__tests__/client.test.ts
@@ -75,7 +75,14 @@ describe('PSI Client', () => {
   })
 
   test('It should process a response (cardinality)', async () => {
-    const client = psi.client!.createWithNewKey()
+    // prettier-ignore
+    const key = Uint8Array.from([
+      160, 193, 102,   5, 219, 141,  42, 183,
+      157, 180,  97, 194,  33, 176,  95, 191,
+       77, 185, 205, 139,  61, 124,   1, 178,
+      198, 110, 236, 127,  64, 242, 152,  15
+    ])
+    const client = psi.client!.createFromKey(key)
 
     // prettier-ignore
     const serverSetup = ServerSetup.deserializeBinary(Uint8Array.from([
@@ -141,7 +148,14 @@ describe('PSI Client', () => {
   })
 
   test('It should process a response (intersection)', async () => {
-    const client = psi.client!.createWithNewKey(true)
+    // prettier-ignore
+    const key = Uint8Array.from([
+      160, 193, 102,   5, 219, 141,  42, 183,
+      157, 180,  97, 194,  33, 176,  95, 191,
+       77, 185, 205, 139,  61, 124,   1, 178,
+      198, 110, 236, 127,  64, 242, 152,  15
+    ])
+    const client = psi.client!.createFromKey(key, true)
 
     // prettier-ignore
     const serverSetup = ServerSetup.deserializeBinary(Uint8Array.from([

--- a/private_set_intersection/python/BUILD
+++ b/private_set_intersection/python/BUILD
@@ -7,6 +7,9 @@ pybind_extension(
     features = ["-use_header_modules"],
     linkstatic = True,
     visibility = ["//visibility:private"],
+    copts = [
+        "--std=c++17"
+    ],
     deps = [
         "//private_set_intersection/cpp:package",
         "//private_set_intersection/cpp:psi_client",


### PR DESCRIPTION
## Description
We don't want to fix a C++ version in .bazelrc. Instead, only targets that need C++17 (currently only `//private_set_intersection/python:__psi_bindings`) should specify it in their `copts `attribute, and all other targest should be C++11 compliant.

Fixes #74 

## Affected Dependencies
None

## How has this been tested?
`bazel test`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
