### PR TITLE
Support for hermetic python interpreter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         run: .github/workflows/scripts/run_tests_core.sh
       - name: Linters
         run: .github/workflows/scripts/lint_cpp.sh
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
   JS:
     runs-on: ${{ matrix.os }}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,8 @@ load("@org_openmined_psi//private_set_intersection:preload.bzl", "psi_preload")
 
 psi_preload()
 
+register_toolchains("//private_set_intersection/python/toolchain:python_toolchain")
+
 load("@org_openmined_psi//private_set_intersection:deps.bzl", "psi_deps")
 
 psi_deps()

--- a/private_set_intersection/deps.bzl
+++ b/private_set_intersection/deps.bzl
@@ -100,7 +100,10 @@ def psi_deps():
     py_repositories()
 
     # Configure python3 for pybind11.
-    python_configure(name = "local_config_python", python_version = "3")
+    python_configure(
+        name = "local_config_python",
+        python_bin = "../python_3_interpreter/bazel_install/bin/python3",  # Use a hermetic python interpreter
+    )
 
     # Install pip requirements for Python tests.
     rules_python_external_dependencies()

--- a/private_set_intersection/preload.bzl
+++ b/private_set_intersection/preload.bzl
@@ -15,6 +15,7 @@
 #
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def psi_preload():
     if "rules_proto" not in native.existing_rules():
@@ -65,9 +66,9 @@ def psi_preload():
     if "pybind11_bazel" not in native.existing_rules():
         http_archive(
             name = "pybind11_bazel",
-            strip_prefix = "pybind11_bazel-203508e14aab7309892a1c5f7dd05debda22d9a5",
-            urls = ["https://github.com/pybind/pybind11_bazel/archive/203508e14aab7309892a1c5f7dd05debda22d9a5.zip"],
-            sha256 = "75922da3a1bdb417d820398eb03d4e9bd067c4905a4246d35a44c01d62154d91",
+            strip_prefix = "pybind11_bazel-4d5fd2acb7284fb715fa973cd84e48156bacb196",
+            urls = ["https://github.com/s0l0ist/pybind11_bazel/archive/4d5fd2acb7284fb715fa973cd84e48156bacb196.zip"],
+            sha256 = "323701a91ebef243511a97917e995ad821029a36ed31e6c878cae9021ed5c942",
         )
 
     if "pybind11" not in native.existing_rules():
@@ -85,6 +86,29 @@ def psi_preload():
             url = "https://github.com/bazelbuild/rules_python/archive/a0fbf98d4e3a232144df4d0d80b577c7a693b570.zip",
             strip_prefix = "rules_python-a0fbf98d4e3a232144df4d0d80b577c7a693b570",
             sha256 = "98c9b903f6e8fe20b7e56d19c4822c8c49a11b475bd4ec0ca6a564e8bc5d5fa2",
+        )
+
+    if "python_3_interpreter" not in native.existing_rules():
+        http_archive(
+            name = "python_3_interpreter",
+            urls = ["https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tar.xz"],
+            sha256 = "dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864",
+            strip_prefix = "Python-3.8.3",
+            patch_cmds = [
+                "mkdir $(pwd)/bazel_install",
+                "./configure --prefix=$(pwd)/bazel_install",
+                "make -j",
+                "make install",
+                "ln -s bazel_install/bin/python3 python_bin",
+            ],
+            build_file_content = """
+exports_files(["python_bin"])
+filegroup(
+    name = "files",
+    srcs = glob(["bazel_install/**"], exclude = ["**/* *"]),
+    visibility = ["//visibility:public"],
+)
+""",
         )
 
     RULES_PYTHON_EXTERNAL_VERSION = "3aacabb928a710b10bff13d0bde49ceaade58f15"

--- a/private_set_intersection/python/BUILD
+++ b/private_set_intersection/python/BUILD
@@ -4,12 +4,12 @@ load("@org_openmined_psi_python_deps//:requirements.bzl", "requirement")
 pybind_extension(
     name = "_psi_bindings",
     srcs = ["psi_bindings.cpp"],
+    copts = [
+        "--std=c++17",
+    ],
     features = ["-use_header_modules"],
     linkstatic = True,
     visibility = ["//visibility:private"],
-    copts = [
-        "--std=c++17"
-    ],
     deps = [
         "//private_set_intersection/cpp:package",
         "//private_set_intersection/cpp:psi_client",

--- a/private_set_intersection/python/toolchain/BUILD
+++ b/private_set_intersection/python/toolchain/BUILD
@@ -1,0 +1,23 @@
+load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
+
+package(default_visibility = ["//visibility:public"])
+
+py_runtime(
+    name = "python_3_runtime",
+    files = ["@python_3_interpreter//:files"],
+    interpreter = "@python_3_interpreter//:python_bin",
+    python_version = "PY3",
+    visibility = ["//visibility:public"],
+)
+
+py_runtime_pair(
+    name = "py_runtime_pair",
+    py2_runtime = None,
+    py3_runtime = ":python_3_runtime",
+)
+
+toolchain(
+    name = "python_toolchain",
+    toolchain = ":py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)


### PR DESCRIPTION
## Description

Removes the system dependence on `python` and replaces it with a hermetic python interpreter for building cross-host 

## Affected Dependencies

- `Python` is no longer required as a system dependency

## How has this been tested?

- [WIP] Python tests/benchmarks pass using the new hermetic interpreter

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
