### PR TITLE
Added function to retrieve C++ PSI library version in Rust

### DIFF
--- a/private_set_intersection/c/BUILD
+++ b/private_set_intersection/c/BUILD
@@ -17,7 +17,7 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "package",
+    name = "c_package",
     srcs = ["package.cpp"],
     hdrs = ["package.h"],
     deps = [
@@ -26,7 +26,7 @@ cc_library(
 )
 
 cc_test(
-    name = "package_test",
+    name = "c_package_test",
     srcs = ["package_test.cpp"],
     deps = [
         ":package",

--- a/private_set_intersection/c/BUILD
+++ b/private_set_intersection/c/BUILD
@@ -29,7 +29,7 @@ cc_test(
     name = "c_package_test",
     srcs = ["package_test.cpp"],
     deps = [
-        ":package",
+        ":c_package",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/private_set_intersection/go/version/BUILD
+++ b/private_set_intersection/go/version/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "version",
     srcs = ["version.go"],
-    cdeps = ["//private_set_intersection/c:package"],
+    cdeps = ["//private_set_intersection/c:c_package"],
     cgo = True,
     importpath = "github.com/openmined/psi/version",
     visibility = ["//visibility:public"],

--- a/private_set_intersection/rust/BUILD
+++ b/private_set_intersection/rust/BUILD
@@ -14,6 +14,7 @@ rust_library(
     deps = [
         "//private_set_intersection/c:c_psi_server",
         "//private_set_intersection/c:c_psi_client",
+        "//private_set_intersection/c:c_package",
         "//third_party/cargo:libc",
         "//third_party/cargo:protobuf",
         "//private_set_intersection/proto:psi_rust_proto"
@@ -22,7 +23,8 @@ rust_library(
 
 rust_test(
     name = "rust_psi_unit_test",
-    crate = ":rust_psi"
+    crate = ":rust_psi",
+    deps = ["//third_party/cargo:semver"]
 )
 
 rust_test(

--- a/private_set_intersection/rust/src/lib.rs
+++ b/private_set_intersection/rust/src/lib.rs
@@ -9,3 +9,26 @@ pub extern crate psi_rust_proto;
 
 pub mod server;
 pub mod client;
+
+use std::ffi::CStr;
+
+extern {
+    fn psi_version() -> *const libc::c_char;
+}
+
+/// Returns the version of the core C++ PSI library.
+pub fn version() -> String {
+    unsafe { CStr::from_ptr(psi_version()).to_str().expect("The version string is not valid UTF-8.").to_owned() }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate semver;
+
+    use super::*;
+
+    #[test]
+    fn test_version() {
+        semver::Version::parse(&version()).expect("The version string is not formatted correctly.");
+    }
+}

--- a/third_party/cargo/BUILD
+++ b/third_party/cargo/BUILD
@@ -18,3 +18,8 @@ alias(
     actual = "@raze__protobuf__2_8_2//:protobuf",
     tags = ["cargo-raze"],
 )
+alias(
+    name = "semver",
+    actual = "@raze__semver__0_10_0//:semver",
+    tags = ["cargo-raze"],
+)

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -8,6 +8,7 @@ path = "fake_lib.rs"
 [dependencies]
 libc = "=0.2.74"
 protobuf = "=2.8.2"
+semver = "=0.10.0"
 
 [raze]
 workspace_path = "//third_party/cargo"

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -32,3 +32,19 @@ def raze_fetch_remote_crates():
         build_file = Label("//third_party/cargo/remote:protobuf-2.8.2.BUILD"),
     )
 
+    _new_http_archive(
+        name = "raze__semver__0_10_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/semver/semver-0.10.0.crate",
+        type = "tar.gz",
+        strip_prefix = "semver-0.10.0",
+        build_file = Label("//third_party/cargo/remote:semver-0.10.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__semver_parser__0_7_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/semver-parser/semver-parser-0.7.0.crate",
+        type = "tar.gz",
+        strip_prefix = "semver-parser-0.7.0",
+        build_file = Label("//third_party/cargo/remote:semver-parser-0.7.0.BUILD"),
+    )
+

--- a/third_party/cargo/remote/semver-0.10.0.BUILD
+++ b/third_party/cargo/remote/semver-0.10.0.BUILD
@@ -1,0 +1,48 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "deprecation" with type "test" omitted
+# Unsupported target "diesel" with type "test" omitted
+
+rust_library(
+    name = "semver",
+    crate_type = "lib",
+    deps = [
+        "@raze__semver_parser__0_7_0//:semver_parser",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.10.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+    ],
+)
+
+# Unsupported target "serde" with type "test" omitted

--- a/third_party/cargo/remote/semver-parser-0.7.0.BUILD
+++ b/third_party/cargo/remote/semver-parser-0.7.0.BUILD
@@ -1,0 +1,43 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third_party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "semver_parser",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.7.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+


### PR DESCRIPTION
## Description
Now able to retrieve the version of the core PSI library in Rust.

## Affected Dependencies
Added a dependency on `semver` for checking version strings.

## How has this been tested?
Tested using `semver` crate.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
