### PR TITLE
Benchmark for GCS vs Bloom Filter tradeoff

### DIFF
--- a/private_set_intersection/cpp/golomb.cpp
+++ b/private_set_intersection/cpp/golomb.cpp
@@ -145,7 +145,8 @@ std::vector<int64_t> golomb_intersect(
       break;
     }
 
-    // get the position of the first 1 bit, which is the end of the unary portion
+    // get the position of the first 1 bit, which is the end of the unary
+    // portion
     auto ctz = static_cast<int64_t>(CTZ(
         static_cast<unsigned int>(static_cast<unsigned char>(*it) >> offset)));
     quotient += ctz;
@@ -168,7 +169,8 @@ std::vector<int64_t> golomb_intersect(
       ++it;
     }
 
-    // if the while loop is executed, then we may have erroneously skipped a byte
+    // if the while loop is executed, then we may have erroneously skipped a
+    // byte
     offset = (one_idx + 1 + div) % CHAR_SIZE;
     it -= static_cast<size_t>((div > 0) & (offset != 0));
 
@@ -176,7 +178,8 @@ std::vector<int64_t> golomb_intersect(
     auto delta = (quotient << div) | remainder;
     prefix_sum += delta;
 
-    // now, check if the current the other (sorted) set contains the current prefix_sum
+    // now, check if the current the other (sorted) set contains the current
+    // prefix_sum
 
     while (arr_it != sorted_arr.end() && (*arr_it).first < prefix_sum) {
       ++arr_it;

--- a/private_set_intersection/cpp/psi_benchmark.cpp
+++ b/private_set_intersection/cpp/psi_benchmark.cpp
@@ -138,7 +138,7 @@ void BM_ClientProcessResponse(benchmark::State& state, bool reveal_intersection,
   }
   std::vector<std::string> client_inputs(num_client_inputs);
   for (int i = 0; i < num_client_inputs; i++) {
-    client_inputs[i] = absl::StrCat("Missing", i);
+    client_inputs[i] = absl::StrCat("Element", i);
   }
   psi_proto::ServerSetup setup =
       server->CreateSetupMessage(fpr, num_inputs, inputs, ds).ValueOrDie();

--- a/private_set_intersection/cpp/psi_benchmark.cpp
+++ b/private_set_intersection/cpp/psi_benchmark.cpp
@@ -124,18 +124,26 @@ BENCHMARK_CAPTURE(BM_ServerProcessRequest, intersection, true)
     ->Range(1, 10000);
 
 void BM_ClientProcessResponse(benchmark::State& state, bool reveal_intersection,
-                              DataStructure ds) {
+                              DataStructure ds, double percentClientSize) {
   auto client = PsiClient::CreateWithNewKey(reveal_intersection).ValueOrDie();
   auto server = PsiServer::CreateWithNewKey(reveal_intersection).ValueOrDie();
   int num_inputs = state.range(0);
+  int num_client_inputs =
+      static_cast<int>(static_cast<double>(state.range(0)) * percentClientSize);
+  num_client_inputs = num_client_inputs == 0 ? 1 : num_client_inputs;
   double fpr = 1. / (1000000);
   std::vector<std::string> inputs(num_inputs);
   for (int i = 0; i < num_inputs; i++) {
     inputs[i] = absl::StrCat("Element", i);
   }
+  std::vector<std::string> client_inputs(num_client_inputs);
+  for (int i = 0; i < num_client_inputs; i++) {
+    client_inputs[i] = absl::StrCat("Missing", i);
+  }
   psi_proto::ServerSetup setup =
       server->CreateSetupMessage(fpr, num_inputs, inputs, ds).ValueOrDie();
-  psi_proto::Request request = client->CreateRequest(inputs).ValueOrDie();
+  psi_proto::Request request =
+      client->CreateRequest(client_inputs).ValueOrDie();
   psi_proto::Response response = server->ProcessRequest(request).ValueOrDie();
   int64_t elements_processed = 0;
   for (auto _ : state) {
@@ -152,21 +160,38 @@ void BM_ClientProcessResponse(benchmark::State& state, bool reveal_intersection,
       static_cast<double>(elements_processed), benchmark::Counter::kIsRate);
 }
 // Range is for the number of inputs.
-BENCHMARK_CAPTURE(BM_ClientProcessResponse, size gcs, false, DataStructure::GCS)
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, size gcs, false, DataStructure::GCS,
+                  1.0)
     ->RangeMultiplier(10)
     ->Range(1, 10000);
 BENCHMARK_CAPTURE(BM_ClientProcessResponse, intersection gcs, true,
-                  DataStructure::GCS)
+                  DataStructure::GCS, 1.0)
     ->RangeMultiplier(10)
     ->Range(1, 10000);
 BENCHMARK_CAPTURE(BM_ClientProcessResponse, size bloom, false,
-                  DataStructure::BloomFilter)
+                  DataStructure::BloomFilter, 1.0)
     ->RangeMultiplier(10)
     ->Range(1, 10000);
 BENCHMARK_CAPTURE(BM_ClientProcessResponse, intersection bloom, true,
-                  DataStructure::BloomFilter)
+                  DataStructure::BloomFilter, 1.0)
     ->RangeMultiplier(10)
     ->Range(1, 10000);
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, size gcs asymmetric, false,
+                  DataStructure::GCS, 0.001)
+    ->RangeMultiplier(10)
+    ->Range(10000, 100000);
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, intersection gcs asymmetric, true,
+                  DataStructure::GCS, 0.001)
+    ->RangeMultiplier(10)
+    ->Range(10000, 100000);
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, size bloom asymmetric, false,
+                  DataStructure::BloomFilter, 0.001)
+    ->RangeMultiplier(10)
+    ->Range(10000, 100000);
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, intersection bloom asymmetric, true,
+                  DataStructure::BloomFilter, 0.001)
+    ->RangeMultiplier(10)
+    ->Range(10000, 100000);
 
 }  // namespace
 }  // namespace private_set_intersection

--- a/private_set_intersection/cpp/psi_client.h
+++ b/private_set_intersection/cpp/psi_client.h
@@ -130,6 +130,8 @@ class PsiClient {
   // response received from the server after sending the result of
   // `CreateRequest`.
   //
+  // Note that the intersections are returned in arbitrary order.
+  //
   // Returns INVALID_ARGUMENT if any input messages are malformed, or INTERNAL
   // if decryption fails.
   StatusOr<std::vector<int64_t>> GetIntersection(

--- a/private_set_intersection/cpp/psi_server.h
+++ b/private_set_intersection/cpp/psi_server.h
@@ -52,7 +52,7 @@ class PsiServer {
       const std::string& key_bytes, bool reveal_intersection);
 
   // Creates a setup message from the server's dataset to be sent to the
-  // client. The setup message is a Bloom filter containing
+  // client. The setup message is a set containing
   // H(x)^s for each element x in `inputs`, where s is the server's secret
   // key. The setup is sent to the client as a serialized protobuf with
   // the following form:
@@ -65,6 +65,12 @@ class PsiServer {
   // `bits` is a binary string.
   // The false-positive rate `fpr` is the probability that any query of size
   // `num_client_inputs` will result in a false positive.
+  //
+  // By default, Golomb Compressed Sets are used as the underlying set data
+  // structure. If the number of client elements is expected to be orders
+  // of magnitude lower than the number of server elements, then Bloom
+  // Filters may be faster. Otherwise, Golomb Compressed Sets can achieve
+  // better compression, so it is better for network transfer.
   //
   // Returns INTERNAL if encryption fails.
   StatusOr<psi_proto::ServerSetup> CreateSetupMessage(

--- a/private_set_intersection/cpp/psi_server_test.cpp
+++ b/private_set_intersection/cpp/psi_server_test.cpp
@@ -44,7 +44,7 @@ TEST_F(PsiServerTest, TestCorrectnessIntersection) {
   // on its own in psi_client_test.cpp.
   PSI_ASSERT_OK_AND_ASSIGN(auto client, PsiClient::CreateWithNewKey(true));
   int num_client_elements = 1000, num_server_elements = 10000;
-  double fpr = 0.01;
+  double fpr = 0.0001;
   std::vector<std::string> client_elements(num_client_elements);
   std::vector<std::string> server_elements(num_server_elements);
 


### PR DESCRIPTION
## Description
Added some benchmarks and some comments on the tradeoff between Bloom Filters and Golomb Compressed Sets.

In summary:
- A GCS is smaller than a Bloom Filter by 25-30%.
- When the client set is orders of magnitude smaller than the server set, then a GCS is slower than a Bloom Filter (GCS cannot do efficient random access). The speed sacrifice should not be too significant: with a 1000x smaller client set (server set of 10^4 or 10^5 elements), GCS is slightly slower than Bloom Filters.

A more thorough updating of the documentation is needed for the newly added GCS data structure.

## Affected Dependencies
N/A

## How has this been tested?
N/A

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
