### PR TITLE
fix: add proto definitions to bundle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Version 0.3.1
+
+Fix:
+
+- Adds protobuf TypeScript definitions to the bundle.
+
 # Version 0.3.0
 
 Feat:

--- a/private_set_intersection/javascript/scripts/postrollup.sh
+++ b/private_set_intersection/javascript/scripts/postrollup.sh
@@ -7,6 +7,9 @@ cp -rf private_set_intersection/javascript/README.md private_set_intersection/ja
 cp -rf LICENSE private_set_intersection/javascript/dist
 cp -rf CHANGES.md private_set_intersection/javascript/dist
 
+# Need to copy the protobuf definitions manually as rollup doesn't do this
+mkdir -p private_set_intersection/javascript/dist/implementation/proto && cp -rf private_set_intersection/javascript/src/implementation/proto/psi_pb.d.ts private_set_intersection/javascript/dist/implementation/proto
+
 # Change directory into dist and pack to get
 # shorter deep import links.
 # Ex: 

--- a/tools/package.bzl
+++ b/tools/package.bzl
@@ -1,2 +1,2 @@
 """ Version of the current release """
-VERSION_LABEL = "0.3.0"
+VERSION_LABEL = "0.3.1"


### PR DESCRIPTION
## Description

JS/TS bundle was missing protobuf definitions. Rollup doesn't do this automatically so we need a work around to copy in the generated file.

## Affected Dependencies
N/A

## How has this been tested?
- CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
