### PR TITLE
Relax Python protobuf version requirement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Version 1.0.2
+
+Feat:
+
+- This patch version relaxes the Python requirement to allow for older `protobuf` libraries to work with the PSI library.
+
 # Version 1.0.1
 
 Feat:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmined/psi.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmined/psi.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Private Set Intersection for JavaScript",
   "repository": {
     "type": "git",

--- a/private_set_intersection/python/BUILD
+++ b/private_set_intersection/python/BUILD
@@ -102,7 +102,7 @@ py_wheel(
     }),
     python_requires = ">=3.8",
     python_tag = "INTERPRETER",
-    requires = ["protobuf==4.21.12"],
+    requires = ["protobuf>=3.20"],
     version = VERSION_LABEL,
     deps = [
         ":openmined_psi_pkg",

--- a/private_set_intersection/python/requirements.in
+++ b/private_set_intersection/python/requirements.in
@@ -4,4 +4,4 @@ pytest==7.2.0
 pytest-benchmark==4.0.0
 twine==4.0.2
 packaging==22.0
-protobuf==4.21.12 # must be updated in wheel rule!
+protobuf>=3.20 # must be updated in wheel rule!

--- a/private_set_intersection/python/requirements.txt
+++ b/private_set_intersection/python/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-attrs==22.1.0
+attrs==22.2.0
     # via pytest
 black==22.12.0
     # via -r requirements.in
@@ -20,13 +20,13 @@ commonmark==0.9.1
     # via rich
 docutils==0.19
     # via readme-renderer
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 flake8==6.0.0
     # via -r requirements.in
 idna==3.4
     # via requests
-importlib-metadata==5.2.0
+importlib-metadata==6.0.0
     # via
     #   keyring
     #   twine
@@ -48,9 +48,9 @@ packaging==22.0
     #   pytest
 pathspec==0.10.3
     # via black
-pkginfo==1.9.2
+pkginfo==1.9.5
     # via twine
-platformdirs==2.6.0
+platformdirs==2.6.2
     # via black
 pluggy==1.0.0
     # via pytest
@@ -62,7 +62,7 @@ pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   rich
@@ -82,7 +82,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==12.6.0
+rich==13.0.1
     # via twine
 six==1.16.0
     # via bleach

--- a/tools/package.bzl
+++ b/tools/package.bzl
@@ -1,2 +1,2 @@
 """ Version of the current release """
-VERSION_LABEL = "1.0.1"
+VERSION_LABEL = "1.0.2"


### PR DESCRIPTION
## Description
This PR relaxes the requrement to use the latest `protobuf` library with the Python wheel to `3.20+`.

## Affected Dependencies
N/A

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

Installed  `protobuf==3.20.2`, built and installed the wheel and ran the tests outside of bazel to verify that the runtime is using the installed wheel and protobuf combination.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
