### PR TITLE
Change CI badges and run only on pull_request

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 # Cancel in progress workflows on pull_requests.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![om-logo](https://github.com/OpenMined/design-assets/blob/master/logos/OM/horizontal-primary-trans.png)
 
-[![CI_CD](https://github.com/OpenMined/PSI/actions/workflows/CI_CD.yml/badge.svg?event=push)](https://github.com/OpenMined/PSI/actions/workflows/CI_CD.yml)
+[![CI](https://github.com/OpenMined/PSI/actions/workflows/CI.yml/badge.svg)](https://github.com/OpenMined/PSI/actions/workflows/CI.yml)
 ![License](https://img.shields.io/github/license/OpenMined/PSI)
 ![OpenCollective](https://img.shields.io/opencollective/all/openmined)
 

--- a/private_set_intersection/javascript/README.md
+++ b/private_set_intersection/javascript/README.md
@@ -1,6 +1,6 @@
 ![om-logo](https://github.com/OpenMined/design-assets/blob/master/logos/OM/horizontal-primary-trans.png)
 
-[![CI_CD](https://github.com/OpenMined/PSI/actions/workflows/CI_CD.yml/badge.svg?event=push)](https://github.com/OpenMined/PSI/actions/workflows/CI_CD.yml)
+[![CI](https://github.com/OpenMined/PSI/actions/workflows/CI.yml/badge.svg)](https://github.com/OpenMined/PSI/actions/workflows/CI.yml)
 ![License](https://img.shields.io/github/license/OpenMined/PSI)
 ![OpenCollective](https://img.shields.io/opencollective/all/openmined)
 


### PR DESCRIPTION
## Description
Code changes must happen in PRs; therefore, we change the `CI` job to run only on PRs.

## Affected Dependencies
N/A
