### PR TITLE
Support new PEP 600 tagging for Python wheels

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Version 1.0.3
+
+Bugfix:
+
+- The Python builds were using the older `manylinux2014` tagging convention which was causing issues on systems that expected a specific glibc version (Ubuntu 20.04 uses [2.31](https://launchpad.net/ubuntu/+source/glibc)). We now use the latest `manylinux_x_y` tagging convention to accomodate different glibc versions across linux when building wheels. This means we must support `python 3.8.10+, 3.9.5+, 3.10.0+` and `pip >= 20.3` in accordance with [PEP 600](https://github.com/pypa/manylinux)
+
 # Version 1.0.2
 
 Feat:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmined/psi.js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmined/psi.js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Private Set Intersection for JavaScript",
   "repository": {
     "type": "git",

--- a/private_set_intersection/python/BUILD
+++ b/private_set_intersection/python/BUILD
@@ -97,7 +97,7 @@ py_wheel(
         "@bazel_tools//src/conditions:windows_arm64": "win_arm64",
         "@bazel_tools//src/conditions:darwin_x86_64": "macosx_12_0_x86_64",
         "@bazel_tools//src/conditions:darwin_arm64": "macosx_12_0_arm64",
-        "@bazel_tools//src/conditions:linux_x86_64": "manylinux2_GLIBC_x86_64",
+        "@bazel_tools//src/conditions:linux_x86_64": "manylinux_GLIBC_x86_64",
         "@bazel_tools//src/conditions:linux_aarch64": "manylinux_GLIBC_aarch64",
     }),
     python_requires = ">=3.8.10",  # Required for linux's wheel naming convention

--- a/private_set_intersection/python/BUILD
+++ b/private_set_intersection/python/BUILD
@@ -97,10 +97,10 @@ py_wheel(
         "@bazel_tools//src/conditions:windows_arm64": "win_arm64",
         "@bazel_tools//src/conditions:darwin_x86_64": "macosx_12_0_x86_64",
         "@bazel_tools//src/conditions:darwin_arm64": "macosx_12_0_arm64",
-        "@bazel_tools//src/conditions:linux_x86_64": "manylinux2014_x86_64",
-        "@bazel_tools//src/conditions:linux_aarch64": "manylinux2014_aarch64",
+        "@bazel_tools//src/conditions:linux_x86_64": "manylinux2_GLIBC_x86_64",
+        "@bazel_tools//src/conditions:linux_aarch64": "manylinux_GLIBC_aarch64",
     }),
-    python_requires = ">=3.8",
+    python_requires = ">=3.8.10",  # Required for linux's wheel naming convention
     python_tag = "INTERPRETER",
     requires = ["protobuf>=3.20"],
     version = VERSION_LABEL,

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -1,6 +1,6 @@
 # This file is used to rename the wheel generated via py_wheel with values
 # determined at runtime
-import sys, os, re
+import sys, os, re, platform
 from packaging import tags
 
 
@@ -21,6 +21,13 @@ def main():
     # INTERPRETER and ABI should be the same value
     outfile = re.sub(r"INTERPRETER", abi_tag, inputfile)
     outfile = re.sub(r"ABI", abi_tag, outfile)
+    system = platform.system()
+
+    # Rename the wheel depending on the version of glibc
+    if system.lower() == "linux":
+        version = platform.libc_ver()[1]
+        glibc_version = version.replace(".", "_")
+        outfile = re.sub(r"GLIBC", glibc_version, outfile)
 
     print("renaming ", inputfile, outfile)
     os.rename(inputfile, outfile)

--- a/tools/package.bzl
+++ b/tools/package.bzl
@@ -1,2 +1,2 @@
 """ Version of the current release """
-VERSION_LABEL = "1.0.2"
+VERSION_LABEL = "1.0.3"


### PR DESCRIPTION
## Description

Previously, we built wheels using `manylinux2014` which was causing compatibility issues on older OSes using different glibc versions. This PR addresses the compatibility issues by using the newer [PEP 600](https://github.com/pypa/manylinux) convention where `manylinux_x_y` represents the supported versions of glibc.

We update the `CD` workflow to publish from Ubuntu 20.04 to build the appropriate wheel with the new naming convention.

## Affected Dependencies
- Python and pip version support have changed to align with [PEP 600](https://github.com/pypa/manylinux)  . `python 3.8.10+, 3.9.5+, 3.10.0+` and `pip >= 20.3`.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

CI passes, tested changes on the test PyPi domain and installed on an Ubuntu 20.04 VM.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
