### PR TITLE
Better python wheels to support 3.8.0+

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -102,7 +102,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        # Handling boundary conditions of: https://github.com/pypa/manylinux
+        python-version: ['3.8.0', '3.8.4', '3.8.10', '3.9.0', '3.9.5', '3.10.0']
         os: [ubuntu-22.04, ubuntu-20.04, macos-12]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -96,14 +96,38 @@ jobs:
 
   # Publish python releases only if all other tests have passed after creating a
   # release.
-  Publish-python:
+  Publish-python-legacy:
     needs: [Core, JS, Go, Python, Rust]
     if: ${{ github.event_name == 'release' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # Handling boundary conditions of: https://github.com/pypa/manylinux
-        python-version: ['3.8.0', '3.8.4', '3.8.10', '3.9.0', '3.9.5', '3.10.0']
+        python-version: ['3.8.0', '3.8.4', '3.9.0']
+        os: [ubuntu-20.04]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build and publish the python wheel
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine packaging
+          bazel build -c opt //private_set_intersection/python:wheel
+          python private_set_intersection/python/rename.py
+          twine upload --skip-existing bazel-bin/private_set_intersection/python/openmined.psi-*
+  Publish-python:
+    needs: [Core, JS, Go, Python, Rust]
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
         os: [ubuntu-22.04, ubuntu-20.04, macos-12]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/scripts/run_tests_python.sh
+++ b/.github/workflows/scripts/run_tests_python.sh
@@ -1,12 +1,7 @@
 #!/bin/sh
 set -e
 
-python -m pip install --upgrade pip
 pip install -r private_set_intersection/python/requirements.txt
 
 # Python + Bazel
 bazel test -c opt --test_output=all //private_set_intersection/python:tests
-
-# Python package
-# pip install .
-# python private_set_intersection/python/tests.py

--- a/private_set_intersection/python/BUILD
+++ b/private_set_intersection/python/BUILD
@@ -97,10 +97,10 @@ py_wheel(
         "@bazel_tools//src/conditions:windows_arm64": "win_arm64",
         "@bazel_tools//src/conditions:darwin_x86_64": "macosx_12_0_x86_64",
         "@bazel_tools//src/conditions:darwin_arm64": "macosx_12_0_arm64",
-        "@bazel_tools//src/conditions:linux_x86_64": "manylinux_GLIBC_x86_64",
-        "@bazel_tools//src/conditions:linux_aarch64": "manylinux_GLIBC_aarch64",
+        "@bazel_tools//src/conditions:linux_x86_64": "LINUX_x86_64",
+        "@bazel_tools//src/conditions:linux_aarch64": "LINUX_aarch64",
     }),
-    python_requires = ">=3.8.10",  # Required for linux's wheel naming convention
+    python_requires = ">=3.8.0",
     python_tag = "INTERPRETER",
     requires = ["protobuf>=3.20"],
     version = VERSION_LABEL,

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -1,7 +1,26 @@
 # This file is used to rename the wheel generated via py_wheel with values
 # determined at runtime
 import sys, os, re, platform
-from packaging import tags
+from packaging import tags, version
+from platform import python_version
+from enum import Enum
+
+
+class ABIVersion(Enum):
+    MANY_LINUX_X_Y = "manylinux_" + str(platform.libc_ver()[1].replace(".", "_"))
+    MANY_LINUX_2014 = "manylinux2014"
+    MANY_LINUX_2010 = "manylinux2010"
+
+
+# In python 3.7+, insertion order is guaranteed
+python_versions = {
+    version.parse("3.10.0"): ABIVersion.MANY_LINUX_X_Y,
+    version.parse("3.9.5"): ABIVersion.MANY_LINUX_X_Y,
+    version.parse("3.9.0"): ABIVersion.MANY_LINUX_2014,
+    version.parse("3.8.10"): ABIVersion.MANY_LINUX_X_Y,
+    version.parse("3.8.4"): ABIVersion.MANY_LINUX_2014,
+    version.parse("3.8.0"): ABIVersion.MANY_LINUX_2010,
+}
 
 
 def main():
@@ -17,17 +36,22 @@ def main():
     interpreter_version = tags.interpreter_version()
     abi_tag = interpreter_name + interpreter_version
 
-    # openmined.psi-1.0.0-INTERPRETER-ABI-PLATFORM.whl
+    # openmined.psi-1.0.0-INTERPRETER-ABI-PLATFORM-ARCH.whl
     # INTERPRETER and ABI should be the same value
     outfile = re.sub(r"INTERPRETER", abi_tag, inputfile)
     outfile = re.sub(r"ABI", abi_tag, outfile)
     system = platform.system()
 
-    # Rename the wheel depending on the version of glibc
+    # We rename the wheel depending on the version of python and glibc
     if system.lower() == "linux":
-        version = platform.libc_ver()[1]
-        glibc_version = version.replace(".", "_")
-        outfile = re.sub(r"GLIBC", glibc_version, outfile)
+        current_version = version.parse(python_version())
+        manylinux = ABIVersion.MANY_LINUX_X_Y.value()
+        for (ver, ml) in python_versions.items():
+            if current_version >= ver:
+                manylinux = ml.value()
+                break
+
+        outfile = re.sub(r"LINUX", manylinux, outfile)
 
     print("renaming ", inputfile, outfile)
     os.rename(inputfile, outfile)

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -7,7 +7,7 @@ from enum import Enum
 
 
 class ABIVersion(Enum):
-    MANY_LINUX_X_Y = "manylinux_" + platform.libc_ver()[1].replace(".", "_")
+    MANY_LINUX_X_Y = "manylinux_" + str(platform.libc_ver()[1].replace(".", "_"))
     MANY_LINUX_2014 = "manylinux2014"
     MANY_LINUX_2010 = "manylinux2010"
 
@@ -45,10 +45,10 @@ def main():
     # We rename the wheel depending on the version of python and glibc
     if system.lower() == "linux":
         current_version = version.parse(python_version())
-        manylinux = ABIVersion.MANY_LINUX_X_Y.value()
+        manylinux = ABIVersion.MANY_LINUX_X_Y.value
         for (ver, ml) in python_versions.items():
             if current_version >= ver:
-                manylinux = ml.value()
+                manylinux = ml.value
                 break
 
         outfile = re.sub(r"LINUX", manylinux, outfile)

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -7,7 +7,7 @@ from enum import Enum
 
 
 class ABIVersion(Enum):
-    MANY_LINUX_X_Y = "manylinux_" + str(platform.libc_ver()[1].replace(".", "_"))
+    MANY_LINUX_X_Y = "manylinux_" + platform.libc_ver()[1].replace(".", "_")
     MANY_LINUX_2014 = "manylinux2014"
     MANY_LINUX_2010 = "manylinux2010"
 

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -12,6 +12,9 @@ class ABIVersion(Enum):
     MANY_LINUX_2010 = "manylinux2010"
 
 
+# We rely on the bundled pip versions installed with python to determine the
+# naming variant: https://github.com/pypa/manylinux
+#
 # NOTE: Order matters
 python_versions = {
     version.parse("3.10.0"): ABIVersion.MANY_LINUX_X_Y,

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -12,14 +12,14 @@ class ABIVersion(Enum):
     MANY_LINUX_2010 = "manylinux2010"
 
 
-# In python 3.7+, insertion order is guaranteed
+# NOTE: Order matters
 python_versions = {
     version.parse("3.10.0"): ABIVersion.MANY_LINUX_X_Y,
     version.parse("3.9.5"): ABIVersion.MANY_LINUX_X_Y,
     version.parse("3.9.0"): ABIVersion.MANY_LINUX_2014,
     version.parse("3.8.10"): ABIVersion.MANY_LINUX_X_Y,
     version.parse("3.8.4"): ABIVersion.MANY_LINUX_2014,
-    version.parse("3.8.0"): ABIVersion.MANY_LINUX_2010,
+    version.parse("3.8.0"): ABIVersion.MANY_LINUX_2010,  # Fails for aarch64
 }
 
 

--- a/private_set_intersection/python/requirements.in
+++ b/private_set_intersection/python/requirements.in
@@ -1,5 +1,5 @@
 black==22.12.0
-flake8==5.0.4
+flake8==5.0.4 # must be 5.x for python 3.8
 pytest==7.2.0
 pytest-benchmark==4.0.0
 twine==4.0.2

--- a/private_set_intersection/python/requirements.in
+++ b/private_set_intersection/python/requirements.in
@@ -1,5 +1,5 @@
 black==22.12.0
-flake8==6.0.0
+flake8==5.0.4
 pytest==7.2.0
 pytest-benchmark==4.0.0
 twine==4.0.2

--- a/private_set_intersection/python/requirements.txt
+++ b/private_set_intersection/python/requirements.txt
@@ -8,21 +8,19 @@ attrs==22.2.0
     # via pytest
 black==22.12.0
     # via -r requirements.in
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via black
-commonmark==0.9.1
-    # via rich
 docutils==0.19
     # via readme-renderer
 exceptiongroup==1.1.0
     # via pytest
-flake8==6.0.0
+flake8==5.0.4
     # via -r requirements.in
 idna==3.4
     # via requests
@@ -30,14 +28,18 @@ importlib-metadata==6.0.0
     # via
     #   keyring
     #   twine
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.2.3
     # via keyring
 keyring==23.13.1
     # via twine
+markdown-it-py==2.1.0
+    # via rich
 mccabe==0.7.0
     # via flake8
+mdurl==0.1.2
+    # via markdown-it-py
 more-itertools==9.0.0
     # via jaraco-classes
 mypy-extensions==0.4.3
@@ -46,9 +48,9 @@ packaging==22.0
     # via
     #   -r requirements.in
     #   pytest
-pathspec==0.10.3
+pathspec==0.11.0
     # via black
-pkginfo==1.9.5
+pkginfo==1.9.6
     # via twine
 platformdirs==2.6.2
     # via black
@@ -58,9 +60,9 @@ protobuf==4.21.12
     # via -r requirements.in
 py-cpuinfo==9.0.0
     # via pytest-benchmark
-pycodestyle==2.10.0
+pycodestyle==2.9.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==2.5.0
     # via flake8
 pygments==2.14.0
     # via
@@ -74,7 +76,7 @@ pytest-benchmark==4.0.0
     # via -r requirements.in
 readme-renderer==37.3
     # via twine
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-toolbelt
     #   twine
@@ -82,7 +84,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.0.1
+rich==13.3.1
     # via twine
 six==1.16.0
     # via bleach
@@ -92,11 +94,11 @@ tomli==2.0.1
     #   pytest
 twine==4.0.2
     # via -r requirements.in
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   requests
     #   twine
 webencodings==0.5.1
     # via bleach
-zipp==3.11.0
+zipp==3.12.0
     # via importlib-metadata


### PR DESCRIPTION
## Description

Closes #153 

The required version has been lowered from `3.8.10+` -> `3.8.0+`. This required support to publish the older `manylinux2010` and `manylinux2014` wheels; however, `aarch64` wheels do not support systems with python < `3.8.4`

## Affected Dependencies
-  python dev deps have been modified accordingly to support 3.8.0

## How has this been tested?
- Tested boundary conditions of the `rename.py` script on Ubuntu 20.04 w/ 3.8.0, 3.8.4 using an arm machine.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
