### PR TITLE
Improved performance for the `Raw` container

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Fix:
 Chore:
 
 - Update `C++` benchmarks to include the new `Raw` enum variant
+- Misc fixes to tests which were not rounding correctly and causing CI to fail
+  randomly
 - Update the main README to include a description of the protocol
 
 # Version 2.0.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@ Fix:
 - The `go` integration tests were not using the datastructure param properly.
   The fix did not result in any regression.
 
+Chore:
+
+- Update `C++` benchmarks to include the new `Raw` enum variant
+- Update the main README to include a description of the protocol
+
 # Version 2.0.0
 
 Breaking:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+# Version 2.0.1
+
+Feat:
+
+- Improved the performance of the underlying `Raw` intersection computation from
+  `O(nmlog(m))` -> `O(nlog(n) + max(n, m))`.
+
+Fix:
+
+- The `go` integration tests were not using the parameterized datastructure
+  param. There were no bugs upon identificication.
+
 # Version 2.0.0
 
 Breaking:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,15 @@
 
 Feat:
 
-- Improved the performance of the underlying `Raw` intersection computation from
-  `O(nmlog(m))` -> `O(nlog(n) + max(n, m))`.
+- The performance of the underlying `Raw` intersection computation has improved
+  from `O(nmlog(m))` -> `O(nlog(n) + max(n, m))`; however, internal protobuf
+  deserialization remains as the dominant performance inhibitor for the
+  `client->GetIntersection*` methods.
 
 Fix:
 
 - The `go` integration tests were not using the parameterized datastructure
-  param. There were no bugs upon identificication.
+  param. The fix did not result in any regression.
 
 # Version 2.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 Feat:
 
-- The performance of the underlying `Raw` intersection computation has improved
+- The complexity of the underlying `Raw` intersection computation has improved
   from `O(nmlog(m))` -> `O(nlog(n) + max(n, m))`; however, internal protobuf
   deserialization remains as the dominant performance inhibitor for the
   `client->GetIntersection*` methods.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,8 @@ Feat:
 
 Fix:
 
-- The `go` integration tests were not using the parameterized datastructure
-  param. The fix did not result in any regression.
+- The `go` integration tests were not using the datastructure param properly.
+  The fix did not result in any regression.
 
 # Version 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,76 @@
 
 # PSI
 
-Private Set Intersection protocol based on ECDH, Bloom Filters, and Golomb
-Compressed Sets.
+Private Set Intersection protocol based on ECDH and Golomb Compressed Sets, and
+Bloom Filters.
+
+## Protocol
+
+In PSI, two parties (client and server) each hold a dataset, and at the end of
+the exchange, the client learns the intersection size (cardinality) or the
+intersection values of both datasets. The client doesn't learn the server's set
+and the server learns nothing from the client.
+
+In this library, there are several variants of PSI, some introduce a small
+false-positive rate (i.e., the reported intersection will be slightly larger
+than the actual cardinality), and others that do not generate false positives.
+This behavior is selective and the false-positive rate can be tuned.
+
+The protocol works as follows.
+
+1. Setup (server)
+
+The server encrypts all its elements `x` under a commutative encryption scheme,
+computing `H(x)^s` where `s` is its secret key. The encrypted elements are then
+inserted in a **container**, which is sent to the client in the form of a
+serialized protobuf and resembles the following:
+
+```
+[ H(x_1)^(s), H(x_2)^(s), ... , H(x_n)^(s) ]
+```
+
+2. Request (client)
+
+The client encrypts all their elements `x` using the commutative encryption
+scheme, computing `H(x)^c`, where `c` is its secret key. The encrypted elements
+are sent to the server with a boolean flag, `reveal_intersection`, that
+indicates whether the client wants to learn the elements in the intersection or
+only its size (cardinality). The payload is sent as a serialized protobuf and
+resembles the following:
+
+```
+[ H(x_1)^(c), H(x_2)^(c), ... , H(x_n)^(c) ]
+```
+
+3. Response (server)
+
+For each encrypted element `H(x)^c` received from the client, the server
+encrypts it again under the commutative encryption scheme with its secret key
+`s`, computing `(H(x)^c)^s = H(x)^(cs)`. The result is sent back to the client
+as a serialized protobuf and resembles the following:
+
+```
+[ H(x_1)^(cs), H(x_2)^(cs), ... , H(x_n)^(cs) ]
+```
+
+If `reveal_intersection` is `false`, the array is sorted to hide the order of
+entries from the client.
+
+4. Compute intersection (client)
+
+The client decrypts each element received from the server's response using its
+secret key `c`, computing `(H(x)^(cs))^(1/c) = H(x)^s`. It then checks if each
+element is present in the **container**, and reports the number of matches as
+the intersection size.
+
+The protocol has configurable **containers**. Golomb Compressed Sets (`Gcs`) is
+the default container but it can be overridden to be `BloomFilter` or `Raw`
+encrypted strings. `Gcs` and `BloomFilter` will have false positives whereas
+`Raw` will not.
+
+## Security
+
+See [SECURITY.md](SECURITY.md).
 
 ## Requirements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,41 +5,47 @@ Several caveats should be carefully considered before using PSI.
 ### Information assumed public
 
 1. Server set size
-2. Client set size
-   (Note that Each of these can be turned into upper bounds by adding dummy elements.)
+2. Client set size (Note that Each of these can be turned into upper bounds by
+   adding dummy elements.)
 
 ### Security Limitations for the PSI protocol
 
-There are two configurations for instantiating a new client/server pair by passing in a boolean switch into their respective constructors.
+There are two configurations for instantiating a new client/server pair by
+passing in a boolean switch into their respective constructors.
 
-1. One that reveals only the **size** (cardinality) of the intersection to the client.
+1. One that reveals only the **size** (cardinality) of the intersection to the
+   client.
 2. One that reveals the actual **intersecion** to the client.
 
-In the case of #1, coordinated clients could get the actual intersection. However, server set items not
-in any of the client sets will never be uncovered.
-Situations where it’s feasible for clients to send one request per element in the domain -
-there is a possbility that coordinated clients could uncover server set.
+In the case of #1, coordinated clients could get the actual intersection.
+However, server set items not in any of the client sets will never be uncovered.
+Situations where it’s feasible for clients to send one request per element in
+the domain - there is a possbility that coordinated clients could uncover server
+set.
 
-Presence of new client set members or absence of former client set members can be
-detected by server/eavesdroppers if client secret is reused.
+Presence of new client set members or absence of former client set members can
+be detected by server/eavesdroppers if client secret is reused.
 
-In the absence of any rate limiting and assuming the client and server have enough
-computing power and bandwidth, small domains may be brute-forceable. However, a query
-needs to be performed for each brute-force attempt.
-An example for this situation would be suppose you were trying to limit sending antibody
-tests to people based on whether they’d been in an infected location, so that people would
-have to share their location history to prove they’d been somewhere infected, and you were
-using PSI so people wouldn’t have to share their location history without good reason. If
-your health authority only covers 10 possible geohashes, people could sidestep the PSI step
-entirely and submit location histories which unlock tests by brute force.
+In the absence of any rate limiting and assuming the client and server have
+enough computing power and bandwidth, small domains may be brute-forceable.
+However, a query needs to be performed for each brute-force attempt. An example
+for this situation would be suppose you were trying to limit sending antibody
+tests to people based on whether they’d been in an infected location, so that
+people would have to share their location history to prove they’d been somewhere
+infected, and you were using PSI so people wouldn’t have to share their location
+history without good reason. If your health authority only covers 10 possible
+geohashes, people could sidestep the PSI step entirely and submit location
+histories which unlock tests by brute force.
 
 A potential limitation with the PSI approach is the communication complexity,
-which scales linearly with the size of the larger set. This is of particular concern
-when performing PSI between a constrained device (cellphone) holding a small set, and a
-large service provider (e.g. WhatsApp), such as in the Private Contact Discovery application.
-Assuming a bloom filter is used, the Client set size affects the algorithmic complexity in
-linear time O(n), with a constant number of lookups. The bloom filter has linear size
-in the server's set, hence the algorithmic complexity of our protocol is O(n). However,
-a bloom filter requires a large number of lookups on each query, if the false positive rate
-is low. An alternative is the Golomb Compressed Set, which requires O(n log n) time due to sorting
-operations, but in practice takes around 25-30% less space than a bloom filter.
+which scales linearly with the size of the larger set. This is of particular
+concern when performing PSI between a constrained device (cellphone) holding a
+small set, and a large service provider (e.g. WhatsApp), such as in the Private
+Contact Discovery application. Assuming a bloom filter is used, the Client set
+size affects the algorithmic complexity in linear time O(n), with a constant
+number of lookups. The bloom filter has linear size in the server's set, hence
+the algorithmic complexity of our protocol is O(n). However, a bloom filter
+requires a large number of lookups on each query, if the false positive rate is
+low. An alternative is the Golomb Compressed Set, which requires O(n log n) time
+due to sorting operations, but in practice takes around 25-30% less space than a
+bloom filter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openmined/psi.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openmined/psi.js",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.8.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmined/psi.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Private Set Intersection for JavaScript",
   "repository": {
     "type": "git",

--- a/private_set_intersection/c/integration_test.cpp
+++ b/private_set_intersection/c/integration_test.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#include <math.h>
+
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
@@ -223,7 +225,8 @@ TEST_P(Correctness, intersection) {
 
     // Test if size is approximately as expected (up to 10%).
     EXPECT_GE(intersection_size, num_client_inputs / 2);
-    EXPECT_LT(intersection_size, (num_client_inputs / 2) * 1.1);
+    EXPECT_LT((double)intersection_size,
+              ceil((double(num_client_inputs) / 2.0) * 1.1));
   }
   free(server_setup);
   free(client_request);

--- a/private_set_intersection/cpp/datastructure/raw.cpp
+++ b/private_set_intersection/cpp/datastructure/raw.cpp
@@ -26,8 +26,7 @@
 namespace private_set_intersection {
 
 // Computes the intersection of two collections. The first collection must be a
-// `pair<T, int64_t>` where `int64_t`. The `T` must be the same in the second
-// collection.
+// `pair<T, int64_t>`. The `T` must be the same in the second collection.
 //
 // Requires both collections to be sorted.
 //

--- a/private_set_intersection/cpp/datastructure/raw.cpp
+++ b/private_set_intersection/cpp/datastructure/raw.cpp
@@ -25,16 +25,32 @@
 
 namespace private_set_intersection {
 
+// Computes the intersection of two random access collections.
+//
+// Requires the collections to be sorted.
+//
+// Complexity:
+// - O(max(n, m))
+template <class InputIt1, class InputIt2, class OutputIt>
+void custom_set_intersection(InputIt1 first1, InputIt1 last1, InputIt2 first2,
+                             InputIt2 last2, OutputIt d_first) {
+  auto begin1 = first1;
+  while (first1 != last1 && first2 != last2) {
+    if (*first1 < *first2)
+      ++first1;
+    else {
+      // *first1 and *first2 are equivalent.
+      if (!(*first2 < *first1)) *d_first++ = first1++ - begin1;
+      ++first2;
+    }
+  }
+}
+
 Raw::Raw(std::vector<std::string> elements) : encrypted_(std::move(elements)) {}
 
 StatusOr<std::unique_ptr<Raw>> Raw::Create(int64_t num_client_inputs,
                                            std::vector<std::string> elements) {
-  auto num_server_inputs = static_cast<int64_t>(elements.size());
-
-  // If server inputs < client inputs, add random encrypted values
-  // ...
-
-  // Then we perform a sort to make intersections easier to find
+  // We sort to make intersections easier to find later
   std::sort(elements.begin(), elements.end());
 
   return absl::WrapUnique(new Raw(elements));
@@ -53,15 +69,15 @@ StatusOr<std::unique_ptr<Raw>> Raw::CreateFromProtobuf(
   return absl::WrapUnique(new Raw(encrypted_elements));
 }
 
-std::vector<int64_t> Raw::Intersect(
-    absl::Span<const std::string> elements) const {
+std::vector<int64_t> Raw::Intersect(absl::Span<std::string> elements) const {
   std::vector<int64_t> res;
 
-  for (size_t i = 0; i < elements.size(); i++) {
-    if (std::binary_search(encrypted_.begin(), encrypted_.end(), elements[i])) {
-      res.push_back(i);
-    }
-  }
+  // the server's set is already sorted so we only need to sort the input
+  std::sort(elements.begin(), elements.end());
+  auto server = absl::MakeConstSpan(encrypted_);
+
+  custom_set_intersection(elements.begin(), elements.end(), server.begin(),
+                          server.end(), std::back_inserter(res));
 
   return res;
 }

--- a/private_set_intersection/cpp/datastructure/raw.h
+++ b/private_set_intersection/cpp/datastructure/raw.h
@@ -41,7 +41,8 @@ class Raw {
   static StatusOr<std::unique_ptr<Raw>> CreateFromProtobuf(
       const psi_proto::ServerSetup& encoded_filter);
 
-  std::vector<int64_t> Intersect(absl::Span<const std::string> elements) const;
+  // Calculates the intersection O(n + n*log(n))
+  std::vector<int64_t> Intersect(absl::Span<std::string> elements) const;
 
   // Returns the size of the encrypted elements
   size_t size() const;

--- a/private_set_intersection/cpp/datastructure/raw.h
+++ b/private_set_intersection/cpp/datastructure/raw.h
@@ -41,8 +41,8 @@ class Raw {
   static StatusOr<std::unique_ptr<Raw>> CreateFromProtobuf(
       const psi_proto::ServerSetup& encoded_filter);
 
-  // Calculates the intersection O(n + n*log(n))
-  std::vector<int64_t> Intersect(absl::Span<std::string> elements) const;
+  // Calculates the intersection
+  std::vector<int64_t> Intersect(absl::Span<const std::string> elements) const;
 
   // Returns the size of the encrypted elements
   size_t size() const;

--- a/private_set_intersection/cpp/psi_benchmark.cpp
+++ b/private_set_intersection/cpp/psi_benchmark.cpp
@@ -31,6 +31,23 @@ void BM_ServerSetup(benchmark::State& state, double fpr,
 }
 // Range is for the number of inputs, and the captured argument is the false
 // positive rate for 10k client queries.
+BENCHMARK_CAPTURE(BM_ServerSetup, 0.001 size raw, 0.001, false,
+                  DataStructure::Raw)
+    ->RangeMultiplier(10)
+    ->Range(1, 100000);
+BENCHMARK_CAPTURE(BM_ServerSetup, 0.000001 size raw, 0.000001, false,
+                  DataStructure::Raw)
+    ->RangeMultiplier(10)
+    ->Range(1, 100000);
+BENCHMARK_CAPTURE(BM_ServerSetup, 0.001 intersection raw, 0.001, true,
+                  DataStructure::Raw)
+    ->RangeMultiplier(10)
+    ->Range(1, 100000);
+BENCHMARK_CAPTURE(BM_ServerSetup, 0.000001 intersection raw, 0.000001, true,
+                  DataStructure::Raw)
+    ->RangeMultiplier(10)
+    ->Range(1, 100000);
+
 BENCHMARK_CAPTURE(BM_ServerSetup, 0.001 size gcs, 0.001, false,
                   DataStructure::Gcs)
     ->RangeMultiplier(10)
@@ -159,6 +176,14 @@ void BM_ClientProcessResponse(benchmark::State& state, bool reveal_intersection,
       static_cast<double>(elements_processed), benchmark::Counter::kIsRate);
 }
 // Range is for the number of inputs.
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, size raw, false, DataStructure::Raw,
+                  1.0)
+    ->RangeMultiplier(10)
+    ->Range(1, 10000);
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, intersection raw, true,
+                  DataStructure::Raw, 1.0)
+    ->RangeMultiplier(10)
+    ->Range(1, 10000);
 BENCHMARK_CAPTURE(BM_ClientProcessResponse, size gcs, false, DataStructure::Gcs,
                   1.0)
     ->RangeMultiplier(10)
@@ -175,6 +200,14 @@ BENCHMARK_CAPTURE(BM_ClientProcessResponse, intersection bloom, true,
                   DataStructure::BloomFilter, 1.0)
     ->RangeMultiplier(10)
     ->Range(1, 10000);
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, size raw asymmetric, false,
+                  DataStructure::Raw, 0.001)
+    ->RangeMultiplier(10)
+    ->Range(10000, 100000);
+BENCHMARK_CAPTURE(BM_ClientProcessResponse, intersection raw asymmetric, true,
+                  DataStructure::Raw, 0.001)
+    ->RangeMultiplier(10)
+    ->Range(10000, 100000);
 BENCHMARK_CAPTURE(BM_ClientProcessResponse, size gcs asymmetric, false,
                   DataStructure::Gcs, 0.001)
     ->RangeMultiplier(10)

--- a/private_set_intersection/cpp/psi_client.cpp
+++ b/private_set_intersection/cpp/psi_client.cpp
@@ -132,21 +132,18 @@ StatusOr<std::vector<int64_t>> PsiClient::ProcessResponse(
     case psi_proto::ServerSetup::DataStructureCase::kRaw: {
       // Decode Bloom Filter from the server setup.
       ASSIGN_OR_RETURN(auto container, Raw::CreateFromProtobuf(server_setup));
-      return container->Intersect(
-          absl::MakeConstSpan(&decrypted[0], decrypted.size()));
+      return container->Intersect(absl::MakeSpan(decrypted));
     }
     case psi_proto::ServerSetup::DataStructureCase::kGcs: {
       // Decode GCS from the server setup.
       ASSIGN_OR_RETURN(auto container, GCS::CreateFromProtobuf(server_setup));
-      return container->Intersect(
-          absl::MakeConstSpan(&decrypted[0], decrypted.size()));
+      return container->Intersect(absl::MakeConstSpan(decrypted));
     }
     case psi_proto::ServerSetup::DataStructureCase::kBloomFilter: {
       // Decode Bloom Filter from the server setup.
       ASSIGN_OR_RETURN(auto container,
                        BloomFilter::CreateFromProtobuf(server_setup));
-      return container->Intersect(
-          absl::MakeConstSpan(&decrypted[0], decrypted.size()));
+      return container->Intersect(absl::MakeConstSpan(decrypted));
     }
     default: {
       return absl::InvalidArgumentError("Impossible");

--- a/private_set_intersection/cpp/psi_client.cpp
+++ b/private_set_intersection/cpp/psi_client.cpp
@@ -132,7 +132,7 @@ StatusOr<std::vector<int64_t>> PsiClient::ProcessResponse(
     case psi_proto::ServerSetup::DataStructureCase::kRaw: {
       // Decode Bloom Filter from the server setup.
       ASSIGN_OR_RETURN(auto container, Raw::CreateFromProtobuf(server_setup));
-      return container->Intersect(absl::MakeSpan(decrypted));
+      return container->Intersect(absl::MakeConstSpan(decrypted));
     }
     case psi_proto::ServerSetup::DataStructureCase::kGcs: {
       // Decode GCS from the server setup.

--- a/private_set_intersection/cpp/psi_client.cpp
+++ b/private_set_intersection/cpp/psi_client.cpp
@@ -1,17 +1,17 @@
 //
 // Copyright 2020 the authors listed in CONTRIBUTORS.md
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
 //
 
 #include "private_set_intersection/cpp/psi_client.h"
@@ -35,6 +35,15 @@ PsiClient::PsiClient(
     : ec_cipher_(std::move(ec_cipher)),
       reveal_intersection(reveal_intersection) {}
 
+/**
+ * Creates a new instance of the PsiClient class with a new key pair for
+ * encryption and decryption using ECCommutativeCipher.
+ *
+ * @param reveal_intersection A boolean indicating whether the client wants to
+ * learn the intersection values or only its size (cardinality).
+ * @return A StatusOr object containing a unique pointer to the newly created
+ * instance of the PsiClient class, or a Status object indicating an error.
+ */
 StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateWithNewKey(
     bool reveal_intersection) {
   // Create an EC cipher with curve P-256. This gives 128 bits of security.
@@ -43,10 +52,23 @@ StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateWithNewKey(
       ::private_join_and_compute::ECCommutativeCipher::CreateWithNewKey(
           NID_X9_62_prime256v1,
           ::private_join_and_compute::ECCommutativeCipher::HashType::SHA256));
+
+  // Create a new instance of the PsiClient class using the ECCommutativeCipher
+  // object and the reveal_intersection boolean.
   return absl::WrapUnique(
       new PsiClient(std::move(ec_cipher), reveal_intersection));
 }
 
+/**
+ * @brief Creates a new PsiClient instance using an EC cipher created from the
+ * provided key.
+ *
+ * @param key_bytes The bytes representing the key for the EC cipher.
+ * @param reveal_intersection A boolean flag indicating whether the intersection
+ * should be revealed.
+ * @return A StatusOr object containing either a unique pointer to a PsiClient
+ * instance or an error status.
+ */
 StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateFromKey(
     const std::string& key_bytes, bool reveal_intersection) {
   // Create an EC cipher with curve P-256. This gives 128 bits of security.
@@ -59,6 +81,14 @@ StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateFromKey(
       new PsiClient(std::move(ec_cipher), reveal_intersection));
 }
 
+/**
+ * @brief Creates a request protobuf with encrypted inputs and a reveal flag.
+ *
+ * @param inputs The inputs to encrypt and add to the request protobuf.
+ *
+ * @return A StatusOr object containing the generated request protobuf if
+ * successful, or an error Status if an error occurred.
+ */
 StatusOr<psi_proto::Request> PsiClient::CreateRequest(
     absl::Span<const std::string> inputs) const {
   // Encrypt inputs one by one.
@@ -82,6 +112,15 @@ StatusOr<psi_proto::Request> PsiClient::CreateRequest(
   return request;
 }
 
+/**
+ * @brief Compute the intersection
+ *
+ * @param server_setup The original server's setup
+ * @param server_response The previous server's response
+ *
+ * @return A StatusOr object containing the intersection if successful, or an
+ * error Status if an error occurred.
+ */
 StatusOr<std::vector<int64_t>> PsiClient::GetIntersection(
     const psi_proto::ServerSetup& server_setup,
     const psi_proto::Response& server_response) const {
@@ -96,6 +135,15 @@ StatusOr<std::vector<int64_t>> PsiClient::GetIntersection(
   return intersection;
 }
 
+/**
+ * @brief Compute the intersection (cardinality)
+ *
+ * @param server_setup The original server's setup
+ * @param server_response The previous server's response
+ *
+ * @return A StatusOr object containing the cardinality if successful, or an
+ * error Status if an error occurred.
+ */
 StatusOr<int64_t> PsiClient::GetIntersectionSize(
     const psi_proto::ServerSetup& server_setup,
     const psi_proto::Response& server_response) const {
@@ -104,6 +152,15 @@ StatusOr<int64_t> PsiClient::GetIntersectionSize(
   return static_cast<int64_t>(intersection.size());
 }
 
+/**
+ * @brief Process the server's response to obtain the intersection
+ *
+ * @param server_setup The original server's setup
+ * @param server_response The previous server's response
+ *
+ * @return A StatusOr object containing the intersection if successful, or an
+ * error Status if an error occurred.
+ */
 StatusOr<std::vector<int64_t>> PsiClient::ProcessResponse(
     const psi_proto::ServerSetup& server_setup,
     const psi_proto::Response& server_response) const {
@@ -151,6 +208,11 @@ StatusOr<std::vector<int64_t>> PsiClient::ProcessResponse(
   }
 }
 
+/**
+ * @brief Get the client's private key
+ *
+ * @return The private key as a null-terminated binary string
+ */
 std::string PsiClient::GetPrivateKeyBytes() const {
   std::string key = ec_cipher_->GetPrivateKeyBytes();
   key.insert(key.begin(), 32 - key.length(), '\0');

--- a/private_set_intersection/cpp/psi_client.cpp
+++ b/private_set_intersection/cpp/psi_client.cpp
@@ -1,17 +1,17 @@
 //
 // Copyright 2020 the authors listed in CONTRIBUTORS.md
 //
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not
-// use this file except in compliance with the License. You may obtain a copy of
-// the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations under
-// the License.
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #include "private_set_intersection/cpp/psi_client.h"

--- a/private_set_intersection/cpp/psi_client.cpp
+++ b/private_set_intersection/cpp/psi_client.cpp
@@ -29,6 +29,15 @@
 
 namespace private_set_intersection {
 
+/**
+ * @brief Construct a new Psi Client:: Psi Client object
+ *
+ * @param ec_cipher A unique pointer to a commutative , which is used for
+ * encryption and decryption in the Private Set Intersection (PSI) protocol.
+ * @param reveal_intersection A boolean value indicating whether the
+ * intersection of the two sets should be revealed after the PSI protocol is
+ * completed.
+ */
 PsiClient::PsiClient(
     std::unique_ptr<::private_join_and_compute::ECCommutativeCipher> ec_cipher,
     bool reveal_intersection)
@@ -36,13 +45,12 @@ PsiClient::PsiClient(
       reveal_intersection(reveal_intersection) {}
 
 /**
- * Creates a new instance of the PsiClient class with a new key pair for
+ * @brief Creates a new instance of the PsiClient class with a new key pair for
  * encryption and decryption using ECCommutativeCipher.
  *
  * @param reveal_intersection A boolean indicating whether the client wants to
  * learn the intersection values or only its size (cardinality).
- * @return A StatusOr object containing a unique pointer to the newly created
- * instance of the PsiClient class, or a Status object indicating an error.
+ * @return StatusOr<std::unique_ptr<PsiClient>>
  */
 StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateWithNewKey(
     bool reveal_intersection) {
@@ -66,8 +74,7 @@ StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateWithNewKey(
  * @param key_bytes The bytes representing the key for the EC cipher.
  * @param reveal_intersection A boolean flag indicating whether the intersection
  * should be revealed.
- * @return A StatusOr object containing either a unique pointer to a PsiClient
- * instance or an error status.
+ * @return StatusOr<std::unique_ptr<PsiClient>>
  */
 StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateFromKey(
     const std::string& key_bytes, bool reveal_intersection) {
@@ -86,8 +93,7 @@ StatusOr<std::unique_ptr<PsiClient>> PsiClient::CreateFromKey(
  *
  * @param inputs The inputs to encrypt and add to the request protobuf.
  *
- * @return A StatusOr object containing the generated request protobuf if
- * successful, or an error Status if an error occurred.
+ * @return StatusOr<psi_proto::Request>
  */
 StatusOr<psi_proto::Request> PsiClient::CreateRequest(
     absl::Span<const std::string> inputs) const {
@@ -118,8 +124,7 @@ StatusOr<psi_proto::Request> PsiClient::CreateRequest(
  * @param server_setup The original server's setup
  * @param server_response The previous server's response
  *
- * @return A StatusOr object containing the intersection if successful, or an
- * error Status if an error occurred.
+ * @return StatusOr<std::vector<int64_t>>
  */
 StatusOr<std::vector<int64_t>> PsiClient::GetIntersection(
     const psi_proto::ServerSetup& server_setup,
@@ -141,8 +146,7 @@ StatusOr<std::vector<int64_t>> PsiClient::GetIntersection(
  * @param server_setup The original server's setup
  * @param server_response The previous server's response
  *
- * @return A StatusOr object containing the cardinality if successful, or an
- * error Status if an error occurred.
+ * @return StatusOr<int64_t>
  */
 StatusOr<int64_t> PsiClient::GetIntersectionSize(
     const psi_proto::ServerSetup& server_setup,
@@ -158,8 +162,7 @@ StatusOr<int64_t> PsiClient::GetIntersectionSize(
  * @param server_setup The original server's setup
  * @param server_response The previous server's response
  *
- * @return A StatusOr object containing the intersection if successful, or an
- * error Status if an error occurred.
+ * @return StatusOr<std::vector<int64_t>>
  */
 StatusOr<std::vector<int64_t>> PsiClient::ProcessResponse(
     const psi_proto::ServerSetup& server_setup,

--- a/private_set_intersection/cpp/psi_client.h
+++ b/private_set_intersection/cpp/psi_client.h
@@ -26,24 +26,25 @@ namespace private_set_intersection {
 
 using absl::StatusOr;
 
-// Client side of a Private Set Intersection protocol. In
-// PSI, two parties (client and server) each hold a dataset, and at
-// the end of the protocol the client learns the size of the intersection of
-// both datasets, while no party learns anything beyond that (cardinality mode).
+// Client side of a Private Set Intersection protocol. In PSI, two parties
+// (client and server) each hold a dataset, and at the end of the protocol the
+// client learns the size of the intersection of both datasets, while no party
+// learns anything beyond that (cardinality mode).
 //
-// This variant of PSI introduces a small false-positive rate (i.e.,
-// the reported cardinality will be slightly larger than the actual cardinality.
-// The false positive rate can be tuned by the server.
+// This container selected in this PSI library can introduce a small
+// false-positive rate (i.e., the reported cardinality will be slightly larger
+// than the actual cardinality. This false-positive rate can be tuned by the
+// server.
 //
 // The protocol works as follows.
-//
 //
 // 1. Setup phase
 //
 // The server encrypts all its elements x under a commutative encryption scheme,
-// computing H(x)^s where s is its secret key. The encrypted elements are then
-// inserted in a Bloom filter, which is sent to the client in the form of a
-// serialized protobuf. The protobuf has the following form:
+// computing `H(x)^s` where `s` is its secret key. The encrypted elements are
+// then inserted in a Bloom filter, which is sent to the client in the form of a
+// serialized protobuf. The example `BloomFilter` container protobuf has the
+// following form:
 //
 //   {
 //     "num_hash_functions": <int>,
@@ -70,30 +71,30 @@ using absl::StatusOr;
 //
 // 3. Server response
 //
-// For each encrypted element H(x)^c received from the client, the server
-// encrypts it again under the commutative encryption scheme with its secret
-// key s, computing (H(x)^c)^s = H(x)^(cs). The result is sent back to the
+// For each encrypted element `H(x)^c` received from the client, the server
+// encrypts it again under the commutative encryption scheme with its secret key
+// `s`, computing `(H(x)^c)^s = H(x)^(cs)`. The result is sent back to the
 // client as a serialized protobuf holding the following form:
 //
 //   {
 //     "encrypted_elements": [ H(x_1)^(cs), H(x_2)^(cs), ... ]
 //   }
 //
-// If reveal_intersection is false, the array is sorted to hide the order of
+// If `reveal_intersection` is false, the array is sorted to hide the order of
 // entries from the client.
 //
 // 4. Client computes intersection
 //
 // The client decrypts each element received from the server's response using
-// its secret key c, computing (H(x)^(cs))^(1/c) = H(x)^s. It then checks if
+// its secret key `c`, computing `(H(x)^(cs))^(1/c) = H(x)^s`. It then checks if
 // each element is present in the Bloom filter, and reports the number of
 // matches as the intersection size.
 class PsiClient {
  public:
   PsiClient() = delete;
 
-  // Creates and returns a new client instance with a fresh private key.
-  // If `reveal_intersection` is true, the client learns the elements in the
+  // Creates and returns a new client instance with a fresh private key. If
+  // `reveal_intersection` is true, the client learns the elements in the
   // intersection of the two datasets. Otherwise, only the intersection size is
   // learned.
   //
@@ -101,22 +102,23 @@ class PsiClient {
   static StatusOr<std::unique_ptr<PsiClient>> CreateWithNewKey(
       bool reveal_intersection);
 
-  // Creates and returns a new client instance with the provided private key.
-  // If `reveal_intersection` is true, the client learns the elements in the
+  // Creates and returns a new client instance with the provided private key. If
+  // `reveal_intersection` is true, the client learns the elements in the
   // intersection of the two datasets. Otherwise, only the intersection size is
   // learned.
   //
-  // WARNING: This function should be used with caution, since reusing the
-  // client key for multiple requests can reveal information about the input
-  // sets. If in doubt, use `CreateWithNewKey`.
+  // WARNING: This function is provided for use in deterministic testing and
+  // should be used with caution, since reusing the client key for multiple
+  // requests can reveal information about the input sets. If in doubt, use
+  // `CreateWithNewKey`.
   //
   // Returns INTERNAL if any OpenSSL crypto operations fail.
   static StatusOr<std::unique_ptr<PsiClient>> CreateFromKey(
       const std::string& key_bytes, bool reveal_intersection);
 
-  // Creates a request protobuf to be serialized and sent to the server.
-  // For each input element x, computes H(x)^c, where c is the secret
-  // key of ec_cipher_.
+  // Creates a request protobuf to be serialized and sent to the server. For
+  // each input element x, computes H(x)^c, where c is the secret key of
+  // ec_cipher_.
   //
   // Returns INTERNAL if encryption fails.
   StatusOr<psi_proto::Request> CreateRequest(
@@ -148,8 +150,8 @@ class PsiClient {
       const psi_proto::ServerSetup& server_setup,
       const psi_proto::Response& server_response) const;
 
-  // Returns this instance's private key. This key should only be used to
-  // create other client instances. DO NOT SEND THIS KEY TO ANY OTHER PARTY!
+  // Returns this instance's private key. This key should only be used to create
+  // other client instances. DO NOT SEND THIS KEY TO ANY OTHER PARTY!
   std::string GetPrivateKeyBytes() const;
 
  private:

--- a/private_set_intersection/cpp/psi_client_test.cpp
+++ b/private_set_intersection/cpp/psi_client_test.cpp
@@ -16,6 +16,8 @@
 
 #include "private_set_intersection/cpp/psi_client.h"
 
+#include <math.h>
+
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
@@ -222,7 +224,8 @@ TEST_F(PsiClientTest, TestCorrectnessIntersectionSize) {
 
   // Test if size is approximately as expected (up to 10%).
   EXPECT_GE(intersection_size, num_client_elements / 2);
-  EXPECT_LT(intersection_size, (num_client_elements / 2) * 1.1);
+  EXPECT_LT((double)intersection_size,
+            ceil(((double)num_client_elements / 2.0) * 1.1));
 }
 
 TEST_F(PsiClientTest, FailIfRevealIntersectionDoesntMatch) {

--- a/private_set_intersection/cpp/psi_server.cpp
+++ b/private_set_intersection/cpp/psi_server.cpp
@@ -77,21 +77,18 @@ StatusOr<psi_proto::ServerSetup> PsiServer::CreateSetupMessage(
   switch (ds) {
     case DataStructure::Gcs: {
       // Create a GCS and insert elements into it.
-      ASSIGN_OR_RETURN(
-          auto container,
-          GCS::Create(corrected_fpr, num_client_inputs,
-                      absl::MakeConstSpan(&encrypted[0], encrypted.size())));
+      ASSIGN_OR_RETURN(auto container,
+                       GCS::Create(corrected_fpr, num_client_inputs,
+                                   absl::MakeConstSpan(encrypted)));
 
       // Return the GCS as a Protobuf
       return container->ToProtobuf();
     }
     case DataStructure::BloomFilter: {
       // Create a Bloom Filter and insert elements into it.
-      ASSIGN_OR_RETURN(
-          auto container,
-          BloomFilter::Create(
-              corrected_fpr, num_client_inputs,
-              absl::MakeConstSpan(&encrypted[0], encrypted.size())));
+      ASSIGN_OR_RETURN(auto container,
+                       BloomFilter::Create(corrected_fpr, num_client_inputs,
+                                           absl::MakeConstSpan(encrypted)));
 
       // Return the Bloom Filter as a Protobuf
       return container->ToProtobuf();

--- a/private_set_intersection/cpp/psi_server.cpp
+++ b/private_set_intersection/cpp/psi_server.cpp
@@ -1,17 +1,17 @@
 //
 // Copyright 2020 the authors listed in CONTRIBUTORS.md
 //
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not
-// use this file except in compliance with the License. You may obtain a copy of
-// the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations under
-// the License.
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #include "private_set_intersection/cpp/psi_server.h"

--- a/private_set_intersection/cpp/psi_server.cpp
+++ b/private_set_intersection/cpp/psi_server.cpp
@@ -1,17 +1,17 @@
 //
 // Copyright 2020 the authors listed in CONTRIBUTORS.md
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
 //
 
 #include "private_set_intersection/cpp/psi_server.h"
@@ -29,12 +29,29 @@
 
 namespace private_set_intersection {
 
+/**
+ * @brief Construct a new Psi Server:: Psi Server object
+ *
+ * @param ec_cipher A unique pointer to a commutative , which is used for
+ * encryption and decryption in the Private Set Intersection (PSI) protocol.
+ * @param reveal_intersection A boolean value indicating whether the
+ * intersection of the two sets should be revealed after the PSI protocol is
+ * completed.
+ */
 PsiServer::PsiServer(
     std::unique_ptr<::private_join_and_compute::ECCommutativeCipher> ec_cipher,
     bool reveal_intersection)
     : ec_cipher_(std::move(ec_cipher)),
       reveal_intersection(reveal_intersection) {}
 
+/**
+ * @brief Creates a new instance of the PsiServer class with a new key pair for
+ * encryption and decryption using ECCommutativeCipher.
+ *
+ * @param reveal_intersection A boolean indicating whether the client wants to
+ * learn the intersection values or only its size (cardinality).
+ * @return StatusOr<std::unique_ptr<PsiServer>>
+ */
 StatusOr<std::unique_ptr<PsiServer>> PsiServer::CreateWithNewKey(
     bool reveal_intersection) {
   // Create an EC cipher with curve P-256. This gives 128 bits of security.
@@ -47,6 +64,15 @@ StatusOr<std::unique_ptr<PsiServer>> PsiServer::CreateWithNewKey(
       new PsiServer(std::move(ec_cipher), reveal_intersection));
 }
 
+/**
+ * @brief Creates a new PsiServer instance using an EC cipher created from the
+ * provided key.
+ *
+ * @param key_bytes The bytes representing the key for the EC cipher.
+ * @param reveal_intersection A boolean flag indicating whether the intersection
+ * should be revealed.
+ * @return StatusOr<std::unique_ptr<PsiServer>>
+ */
 StatusOr<std::unique_ptr<PsiServer>> PsiServer::CreateFromKey(
     const std::string& key_bytes, bool reveal_intersection) {
   // Create an EC cipher with curve P-256. This gives 128 bits of security.
@@ -59,6 +85,18 @@ StatusOr<std::unique_ptr<PsiServer>> PsiServer::CreateFromKey(
       new PsiServer(std::move(ec_cipher), reveal_intersection));
 }
 
+/**
+ * @brief Create a server setup message containing the chosen data structure,
+ * based on the provided parameters.
+ *
+ * @param fpr A double representing the false positive rate of the chosen data
+ * structure (This is ignored for the `Raw` datastructure)
+ * @param num_client_inputs The number of client inputs to the PSI protocol
+ * @param inputs The server inputs to the PSI protocol
+ * @param ds A datastructure enum indicating the type of data structure to use
+ * for the PSI protocol
+ * @return StatusOr<psi_proto::ServerSetup>
+ */
 StatusOr<psi_proto::ServerSetup> PsiServer::CreateSetupMessage(
     double fpr, int64_t num_client_inputs, absl::Span<const std::string> inputs,
     DataStructure ds) const {
@@ -106,6 +144,13 @@ StatusOr<psi_proto::ServerSetup> PsiServer::CreateSetupMessage(
   }
 }
 
+/**
+ * @brief Processes a client's request by re-encrypting the request's elements
+ * and creating a response
+ *
+ * @param client_request The request containing the elements to re-encrypt
+ * @return StatusOr<psi_proto::Response>
+ */
 StatusOr<psi_proto::Response> PsiServer::ProcessRequest(
     const psi_proto::Request& client_request) const {
   if (!client_request.IsInitialized()) {
@@ -144,6 +189,11 @@ StatusOr<psi_proto::Response> PsiServer::ProcessRequest(
   return response;
 }
 
+/**
+ * @brief Get the server's private key
+ *
+ * @return The private key as a null-terminated binary string
+ */
 std::string PsiServer::GetPrivateKeyBytes() const {
   std::string key = ec_cipher_->GetPrivateKeyBytes();
   key.insert(key.begin(), 32 - key.length(), '\0');

--- a/private_set_intersection/cpp/psi_server.h
+++ b/private_set_intersection/cpp/psi_server.h
@@ -27,32 +27,36 @@ namespace private_set_intersection {
 
 using absl::StatusOr;
 
-// The server side of a Private Set Intersection protocol.
-// See the documentation in PsiClient for a full description of the
-// protocol.
+// The server side of a Private Set Intersection protocol. See the documentation
+// in PsiClient for a full description of the protocol.
 class PsiServer {
  public:
   PsiServer() = delete;
 
-  // Creates and returns a new server instance with a fresh private key.
-  // If `reveal_intersection` indicates whether the client should learn the
+  // Creates and returns a new server instance with a fresh private key. If
+  // `reveal_intersection` indicates whether the client should learn the
   // intersection or only its size.
   //
   // Returns INTERNAL if any OpenSSL crypto operations fail.
   static StatusOr<std::unique_ptr<PsiServer>> CreateWithNewKey(
       bool reveal_intersection);
 
-  // Creates and returns a new server instance with the provided private key.
-  // If `reveal_intersection` indicates whether the client should learn the
+  // Creates and returns a new server instance with the provided private key. If
+  // `reveal_intersection` indicates whether the client should learn the
   // intersection or only its size.
+  //
+  // WARNING: This function is provided for use in deterministic testing and
+  // should be used with caution, since reusing the client key for multiple
+  // requests can reveal information about the input sets. If in doubt, use
+  // `CreateWithNewKey`.
   //
   // Returns INTERNAL if any OpenSSL crypto operations fail.
   static StatusOr<std::unique_ptr<PsiServer>> CreateFromKey(
       const std::string& key_bytes, bool reveal_intersection);
 
   // Creates a setup message from the server's dataset to be sent to the client.
-  // The setup message is a set containing H(x)^s for each element x in
-  // `inputs`, where s is the server's secret key. The setup is sent to the
+  // The setup message is a set containing `H(x)^s` for each element `x` in
+  // `inputs`, where `s` is the server's secret key. The setup is sent to the
   // client as a serialized protobuf with the following form:
   //
   //   {
@@ -82,10 +86,11 @@ class PsiServer {
       DataStructure ds = DataStructure::Gcs) const;
 
   // Processes a client query and returns the corresponding server response to
-  // be sent to the client. For each encrytped element H(x)^c in the decoded
-  // `client_request`, computes (H(x)^c)^s = H(X)^(cs) and returns these as an
+  // be sent to the client. For each encrytped element `H(x)^c` in the decoded
+  // `client_request`, computes `(H(x)^c)^s = H(X)^(cs)` and returns these as an
   // array inside a protobuf.
-  // If reveal_intersection == false, the resulting array is sorted, which
+  //
+  // If `reveal_intersection` == false, the resulting array is sorted, which
   // prevents the client from matching the individual response elements to the
   // ones in the request, ensuring that they can only learn the intersection
   // size but not individual elements in the intersection.
@@ -95,8 +100,8 @@ class PsiServer {
   StatusOr<psi_proto::Response> ProcessRequest(
       const psi_proto::Request& client_request) const;
 
-  // Returns this instance's private key. This key should only be used to
-  // create other server instances. DO NOT SEND THIS KEY TO ANY OTHER PARTY!
+  // Returns this instance's private key. This key should only be used to create
+  // other server instances. DO NOT SEND THIS KEY TO ANY OTHER PARTY!
   std::string GetPrivateKeyBytes() const;
 
  private:

--- a/private_set_intersection/cpp/psi_server_test.cpp
+++ b/private_set_intersection/cpp/psi_server_test.cpp
@@ -13,8 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-
 #include "private_set_intersection/cpp/psi_server.h"
+
+#include <math.h>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/escaping.h"
@@ -141,7 +142,8 @@ TEST_F(PsiServerTest, TestCorrectnessIntersectionSize) {
 
   // Test if size is approximately as expected (up to 10%).
   EXPECT_GE(intersection_size, num_client_elements / 2);
-  EXPECT_LT(intersection_size, (num_client_elements / 2) * 1.1);
+  EXPECT_LT((double)intersection_size,
+            ceil(((double)num_client_elements / 2.0) * 1.1));
 }
 
 TEST_F(PsiServerTest, TestArrayIsSortedWhenNotRevealingIntersection) {

--- a/private_set_intersection/go/integration_test.go
+++ b/private_set_intersection/go/integration_test.go
@@ -9,6 +9,7 @@ import (
 	psi_version "github.com/openmined/psi/version"
 	"google.golang.org/protobuf/proto"
 	"regexp"
+	"math"
 	"testing"
 )
 
@@ -124,7 +125,7 @@ func TestIntegrationIntersection(t *testing.T) {
 		}
 
 		// Create the setup
-		serverSetup, err := server.CreateSetupMessage(fpr, int64(len(clientInputs)), serverInputs, 0)
+		serverSetup, err := server.CreateSetupMessage(fpr, int64(len(clientInputs)), serverInputs, tc.ds)
 		if err != nil {
 			t.Errorf("Failed to create serverSetup: %v", err)
 		}
@@ -192,7 +193,7 @@ func TestIntegrationIntersection(t *testing.T) {
 				t.Errorf("Invalid intersection. expected lower bound %v. got %v", (numClientInputs / 2), intersectionCnt)
 			}
 
-			if float64(intersectionCnt) > float64(numClientInputs/2)*float64(1.1) {
+			if float64(intersectionCnt) > math.Ceil(float64(numClientInputs/2)*float64(1.1)) {
 				t.Errorf("Invalid intersection. expected upper bound %v. got %v", float64(numClientInputs/2)*float64(1.1), intersectionCnt)
 			}
 

--- a/private_set_intersection/go/integration_test.go
+++ b/private_set_intersection/go/integration_test.go
@@ -194,7 +194,7 @@ func TestIntegrationIntersection(t *testing.T) {
 			}
 
 			if float64(intersectionCnt) > math.Ceil(float64(numClientInputs/2)*float64(1.1)) {
-				t.Errorf("Invalid intersection. expected upper bound %v. got %v", float64(numClientInputs/2)*float64(1.1), intersectionCnt)
+				t.Errorf("Invalid intersection. expected upper bound %v. got %v", math.Ceil(float64(numClientInputs/2)*float64(1.1)), intersectionCnt)
 			}
 
 		}

--- a/private_set_intersection/go/integration_test.go
+++ b/private_set_intersection/go/integration_test.go
@@ -8,8 +8,8 @@ import (
 	psi_server "github.com/openmined/psi/server"
 	psi_version "github.com/openmined/psi/version"
 	"google.golang.org/protobuf/proto"
-	"regexp"
 	"math"
+	"regexp"
 	"testing"
 )
 

--- a/private_set_intersection/rust/tests/integration_test.rs
+++ b/private_set_intersection/rust/tests/integration_test.rs
@@ -71,7 +71,9 @@ fn integration_test() {
                 let intersection_size = client.get_intersection_size(&setup, &response).unwrap();
 
                 assert!(intersection_size >= (NUM_CLIENT_ELEMENTS / 2));
-                assert!((intersection_size as f64) < ((NUM_CLIENT_ELEMENTS as f64) / 2.0 * 1.1));
+                assert!(
+                    (intersection_size as f64) < ((NUM_CLIENT_ELEMENTS as f64) / 2.0 * 1.1).ceil()
+                );
             }
         }
     }

--- a/tools/package.bzl
+++ b/tools/package.bzl
@@ -1,2 +1,2 @@
 """ Version of the current release """
-VERSION_LABEL = "2.0.0"
+VERSION_LABEL = "2.0.1"


### PR DESCRIPTION
## Description

Feat:

- The complexity of the underlying `Raw` intersection computation has improved
  from `O(nmlog(m))` -> `O(nlog(n) + max(n, m))`; however, internal protobuf
  deserialization remains as the dominant performance inhibitor for the
  `client->GetIntersection*` methods.

Fix:

- The `go` integration tests were not using the datastructure param properly.
  The fix did not result in any regression.

Chore:

- Update `C++` benchmarks to include the new `Raw` enum variant
- Misc fixes to tests which were not rounding correctly and causing CI to fail
  randomly
- Update the main README to include a description of the protocol


## Affected Dependencies
N/A

## How has this been tested?
- CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
