### PR TITLE
Rename python package to `openmined_psi`

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-14]
-        golang-version: ['1.21']
+        golang-version: ['1.23']
     steps:
       - name: Set up Golang ${{ matrix.golang-version }}
         uses: actions/setup-go@v5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@ Chore:
 - Minor fixes that the cpp linter was reporting and a fix in the python cpp
   bindings to use absl::MakeSpan instead of passing a std::vector.
 
+Breaking:
+
+- The **python** package has been renamed to `openmined_psi` to comply with the
+  bazel toolchain naming conventions.
+
 # Version 2.0.2
 
 Chore:

--- a/private_set_intersection/python/BUILD
+++ b/private_set_intersection/python/BUILD
@@ -174,7 +174,7 @@ py_package(
 # This rule builds the wheel, but we need to change the name of the .whl before
 # we publish to PyPI using a separate publish script outside of bazel. The
 # output that gets generated looks like the following:
-# openmined.psi-1.0.0-INTERPRETER-ABI-PLATFORM.whl
+# openmined_psi-1.0.0-INTERPRETER-ABI-PLATFORM.whl
 #
 # This rule also bundles protobuf, but it resides in an incorrect directy and
 # there doesn't seem to be a way to prevent it getting added to the wheel.
@@ -188,7 +188,7 @@ py_wheel(
         "Topic :: Security :: Cryptography",
     ],
     description_file = "DESCRIPTION.md",
-    distribution = "openmined.psi",
+    distribution = "openmined_psi",
     extra_distinfo_files = {
         "//:LICENSE": "LICENSE",
         "//private_set_intersection/python:README.md": "README",

--- a/private_set_intersection/python/README.md
+++ b/private_set_intersection/python/README.md
@@ -3,7 +3,15 @@
 Private Set Intersection protocol based on ECDH, Bloom Filters, and Golomb
 Compressed Sets.
 
-## Tests
+## Installation
+
+```bash
+pip install openmined_psi
+```
+
+## Developing
+
+### Tests
 
 ```bash
 bazel test --test_output=all //private_set_intersection/python:test_3_8
@@ -13,7 +21,7 @@ bazel test --test_output=all //private_set_intersection/python:test_3_11
 ...
 ```
 
-## Benchmarks
+### Benchmarks
 
 ```bash
 bazel run -c opt --test_output=all //private_set_intersection/python:benchmark_3_8
@@ -23,7 +31,7 @@ bazel run -c opt --test_output=all //private_set_intersection/python:benchmark_3
 ...
 ```
 
-## Updating dependencies
+### Updating dependencies
 
 Add any dependencies to `requirements.in`, then run:
 
@@ -35,7 +43,7 @@ bazel run //private_set_intersection/python/requirements:requirements_3_11.updat
 ...
 ```
 
-## Publishing
+### Publishing
 
 We first build the wheel
 

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -1,9 +1,9 @@
-# This file is used to rename the wheel generated via py_wheel with values
-# determined at runtime
 import os
 import platform
 import re
+import shutil
 import sys
+import zipfile
 from enum import Enum
 from platform import python_version
 
@@ -30,6 +30,46 @@ python_versions = {
     version.parse("3.8.4"): ABIVersion.MANY_LINUX_2014,
     version.parse("3.8.0"): ABIVersion.MANY_LINUX_2010,  # Fails for aarch64
 }
+
+
+def rename_internal_files(extract_dir):
+    # Traverse the directory and rename files and folders with underscores to use dots
+    for root, dirs, files in os.walk(extract_dir):
+        for filename in files:
+            new_filename = re.sub(r"openmined_psi", "openmined.psi", filename)
+            if new_filename != filename:
+                os.rename(
+                    os.path.join(root, filename), os.path.join(root, new_filename)
+                )
+        for dirname in dirs:
+            new_dirname = re.sub(r"openmined_psi", "openmined.psi", dirname)
+            if new_dirname != dirname:
+                os.rename(os.path.join(root, dirname), os.path.join(root, new_dirname))
+
+
+def process_wheel(inputfile, outfile):
+    extract_dir = inputfile.rstrip(".whl") + "_extracted"
+
+    # Step 1: Extract the .whl (since it's just a zip archive)
+    with zipfile.ZipFile(inputfile, "r") as zip_ref:
+        zip_ref.extractall(extract_dir)
+
+    # Step 2: Rename internal files with underscores to use dots
+    rename_internal_files(extract_dir)
+
+    # Step 3: Re-zip the contents back into a wheel file
+    shutil.make_archive(outfile.rstrip(".whl"), "zip", extract_dir)
+    shutil.move(outfile.rstrip(".whl") + ".zip", outfile)
+
+    # Step 4: Clean up the extracted directory
+    shutil.rmtree(extract_dir)
+
+    # Step 5: Remove the original .whl file if successful
+    if os.path.exists(outfile):
+        os.remove(inputfile)
+        print(f"Successfully renamed and removed the original file: {inputfile}")
+    else:
+        print(f"Renaming failed, keeping the original file: {inputfile}")
 
 
 def main():
@@ -66,8 +106,11 @@ def main():
 
         outfile = re.sub(r"LINUX", manylinux, outfile)
 
-    print("renaming ", inputfile, outfile)
-    os.rename(inputfile, outfile)
+    print("Renaming wheel and its internal contents: ", inputfile, " -> ", outfile)
+    process_wheel(inputfile, outfile)
+
+    # Step 5: Rename the external wheel file (already done in process_wheel)
+    print("Wheel renamed successfully")
 
 
 if __name__ == "__main__":

--- a/private_set_intersection/python/rename.py
+++ b/private_set_intersection/python/rename.py
@@ -1,9 +1,9 @@
+# This file is used to rename the wheel generated via py_wheel with values
+# determined at runtime
 import os
 import platform
 import re
-import shutil
 import sys
-import zipfile
 from enum import Enum
 from platform import python_version
 
@@ -32,46 +32,6 @@ python_versions = {
 }
 
 
-def rename_internal_files(extract_dir):
-    # Traverse the directory and rename files and folders with underscores to use dots
-    for root, dirs, files in os.walk(extract_dir):
-        for filename in files:
-            new_filename = re.sub(r"openmined_psi", "openmined.psi", filename)
-            if new_filename != filename:
-                os.rename(
-                    os.path.join(root, filename), os.path.join(root, new_filename)
-                )
-        for dirname in dirs:
-            new_dirname = re.sub(r"openmined_psi", "openmined.psi", dirname)
-            if new_dirname != dirname:
-                os.rename(os.path.join(root, dirname), os.path.join(root, new_dirname))
-
-
-def process_wheel(inputfile, outfile):
-    extract_dir = inputfile.rstrip(".whl") + "_extracted"
-
-    # Step 1: Extract the .whl (since it's just a zip archive)
-    with zipfile.ZipFile(inputfile, "r") as zip_ref:
-        zip_ref.extractall(extract_dir)
-
-    # Step 2: Rename internal files with underscores to use dots
-    rename_internal_files(extract_dir)
-
-    # Step 3: Re-zip the contents back into a wheel file
-    shutil.make_archive(outfile.rstrip(".whl"), "zip", extract_dir)
-    shutil.move(outfile.rstrip(".whl") + ".zip", outfile)
-
-    # Step 4: Clean up the extracted directory
-    shutil.rmtree(extract_dir)
-
-    # Step 5: Remove the original .whl file if successful
-    if os.path.exists(outfile):
-        os.remove(inputfile)
-        print(f"Successfully renamed and removed the original file: {inputfile}")
-    else:
-        print(f"Renaming failed, keeping the original file: {inputfile}")
-
-
 def main():
     inputfile = ""
     for file in os.listdir("./bazel-bin/private_set_intersection/python"):
@@ -88,11 +48,10 @@ def main():
     interpreter_version = tags.interpreter_version()
     abi_tag = interpreter_name + interpreter_version
 
-    # openmined.psi-1.0.0-INTERPRETER-ABI-PLATFORM-ARCH.whl
+    # openmined_psi-1.0.0-INTERPRETER-ABI-PLATFORM-ARCH.whl
     # INTERPRETER and ABI should be the same value
     outfile = re.sub(r"INTERPRETER", abi_tag, inputfile)
     outfile = re.sub(r"ABI", abi_tag, outfile)
-    outfile = re.sub(r"openmined_psi", "openmined.psi", outfile)
     system = platform.system()
 
     # We rename the wheel depending on the version of python and glibc
@@ -106,11 +65,8 @@ def main():
 
         outfile = re.sub(r"LINUX", manylinux, outfile)
 
-    print("Renaming wheel and its internal contents: ", inputfile, " -> ", outfile)
-    process_wheel(inputfile, outfile)
-
-    # Step 5: Rename the external wheel file (already done in process_wheel)
-    print("Wheel renamed successfully")
+    print("renaming ", inputfile, outfile)
+    os.rename(inputfile, outfile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The python distribution has been renamed to `openmined_psi` to comply with the latest naming [convention for binary distributions](https://packaging.python.org/en/latest/specifications/binary-distribution-format/) which has already been introduced in the `rules_python` bazel dependency.

## Affected Dependencies
 - `pip install openmined.psi` -> `pip install openmined_psi`

## How has this been tested?
- Tested by uploading to test.pypi

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
